### PR TITLE
feat: enable random anti-fee sniping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,20 +11,22 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-miniscript = { version = "12", default-features = false }
+miniscript = { version = "12.3.5", default-features = false }
 bdk_coin_select = "0.4.0"
+rand_core = { version = "0.6.4", default-features = false }
+rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
 bdk_tx = { path = "." }
-bitcoin = { version = "0.32", features = ["rand-std"] }
+bitcoin = { version = "0.32", default-features = false, features = ["rand-std"] }
 bdk_testenv = "0.13.0"
 bdk_bitcoind_rpc = "0.20.0"
 bdk_chain = { version = "0.23.0" }
 
 [features]
 default = ["std"]
-std = ["miniscript/std"]
+std = ["miniscript/std", "rand/std"]
 
 [[example]]
 name = "synopsis"
@@ -32,3 +34,6 @@ name = "synopsis"
 [[example]]
 name = "common"
 crate-type = ["lib"]
+
+[[example]]
+name = "anti_fee_sniping"

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -1,0 +1,150 @@
+#![allow(dead_code)]
+use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_tx::{
+    filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeStrategy, Output,
+    PsbtParams, ScriptSource, SelectorParams,
+};
+use bitcoin::{absolute::LockTime, key::Secp256k1, Amount, FeeRate, Sequence};
+use miniscript::Descriptor;
+
+mod common;
+
+use common::Wallet;
+
+fn main() -> anyhow::Result<()> {
+    let secp = Secp256k1::new();
+    let (external, _) = Descriptor::parse_descriptor(&secp, bdk_testenv::utils::DESCRIPTORS[0])?;
+    let (internal, _) = Descriptor::parse_descriptor(&secp, bdk_testenv::utils::DESCRIPTORS[1])?;
+
+    let env = TestEnv::new()?;
+    let genesis_hash = env.genesis_hash()?;
+    env.mine_blocks(101, None)?;
+
+    let mut wallet = Wallet::new(genesis_hash, external, internal.clone())?;
+    wallet.sync(&env)?;
+
+    let addr = wallet.next_address().expect("must derive address");
+
+    let txid1 = env.send(&addr, Amount::ONE_BTC)?;
+    env.mine_blocks(1, None)?;
+    wallet.sync(&env)?;
+    println!("Received confirmed input: {}", txid1);
+
+    let txid2 = env.send(&addr, Amount::ONE_BTC)?;
+    env.mine_blocks(1, None)?;
+    wallet.sync(&env)?;
+    println!("Received confirmed input: {}", txid2);
+
+    println!("Balance (confirmed): {}", wallet.balance());
+
+    let (tip_height, tip_time) = wallet.tip_info(env.rpc_client())?;
+    println!("Current height: {}", tip_height);
+    let longterm_feerate = FeeRate::from_sat_per_vb_unchecked(1);
+
+    let recipient_addr = env
+        .rpc_client()
+        .get_new_address(None, None)?
+        .assume_checked();
+
+    // When anti-fee-sniping is enabled, the transaction will either use nLockTime or nSequence.
+    //
+    // Locktime approach is used when:
+    // - RBF is disabled, OR
+    // - Any input requires locktime (non-taproot, unconfirmed, or >65535 confirmations), OR
+    // - There are no taproot inputs, OR
+    // - Random 50/50 coin flip chose locktime
+    //
+    // Sequence approach is used otherwise:
+    // - Sets tx.lock_time to ZERO
+    // - Modifies one randomly selected taproot input's sequence
+    //
+    // Once the approach is selected, to reduce transaction fingerprinting,
+    // - For nLockTime: With 10% probability, subtract a random 0-99 block offset from current height
+    // - For nSequence: With 10% probability, subtract a random 0-99 block offset (minimum value of 1)
+    //
+    // Note: When locktime is used, all sequence values remain unchanged.
+
+    let mut locktime_count = 0;
+    let mut sequence_count = 0;
+
+    for _ in 0..10 {
+        let selection = wallet
+            .all_candidates()
+            .regroup(group_by_spk())
+            .filter(filter_unspendable_now(tip_height, tip_time))
+            .into_selection(
+                selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
+                SelectorParams::new(
+                    FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
+                    vec![Output::with_script(
+                        recipient_addr.script_pubkey(),
+                        Amount::from_sat(50_000_000),
+                    )],
+                    ScriptSource::Descriptor(Box::new(internal.at_derivation_index(0)?)),
+                    wallet.change_policy(),
+                ),
+            )?;
+
+        let fallback_locktime: LockTime = LockTime::from_consensus(tip_height.to_consensus_u32());
+
+        let selection_inputs = selection.inputs.clone();
+
+        let psbt = selection.create_psbt(PsbtParams {
+            enable_anti_fee_sniping: true,
+            fallback_locktime,
+            fallback_sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            ..Default::default()
+        })?;
+
+        let tx = psbt.unsigned_tx;
+
+        if tx.lock_time != LockTime::ZERO {
+            locktime_count += 1;
+            let locktime_value = tx.lock_time.to_consensus_u32();
+            let current_height = tip_height.to_consensus_u32();
+
+            let offset = current_height.saturating_sub(locktime_value);
+            if offset > 0 {
+                println!(
+                    "nLockTime = {} (tip height: {}, offset: -{})",
+                    locktime_value, current_height, offset
+                );
+            } else {
+                println!(
+                    "nLockTime = {} (tip height: {}, no offset)",
+                    locktime_value, current_height
+                );
+            }
+        } else {
+            sequence_count += 1;
+
+            for (i, inp) in tx.input.iter().enumerate() {
+                let sequence_value = inp.sequence.to_consensus_u32();
+
+                if (1..0xFFFFFFFD).contains(&sequence_value) {
+                    let input_confirmations = selection_inputs[i].confirmations(tip_height);
+                    let offset = input_confirmations.saturating_sub(sequence_value);
+
+                    if offset > 0 {
+                        println!(
+                            "nSequence[{}] = {} (confirmations: {}, offset: -{})",
+                            i, sequence_value, input_confirmations, offset
+                        );
+                    } else {
+                        println!(
+                            "nSequence[{}] = {} (confirmations: {}, no offset)",
+                            i, sequence_value, input_confirmations
+                        );
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    println!("nLockTime approach used: {} times", locktime_count);
+    println!("nSequence approach used: {} times", sequence_count);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
 //! `bdk_tx`
-
-// FIXME: try to remove clippy "allows"
-#![allow(clippy::large_enum_variant)]
-#![allow(clippy::result_large_err)]
 #![warn(missing_docs)]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod rbf;
 mod selection;
 mod selector;
 mod signer;
+mod utils;
 
 pub use canonical_unspents::*;
 pub use finalizer::*;
@@ -30,6 +31,7 @@ pub use rbf::*;
 pub use selection::*;
 pub use selector::*;
 pub use signer::*;
+use utils::*;
 
 #[cfg(feature = "std")]
 pub(crate) mod collections {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,12 +1,17 @@
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 
 use bdk_coin_select::FeeRate;
-use bitcoin::{absolute, transaction, Sequence};
 use miniscript::bitcoin;
+use miniscript::bitcoin::{
+    absolute::{self, LockTime},
+    transaction, Psbt, Sequence,
+};
 use miniscript::psbt::PsbtExt;
+use rand_core::RngCore;
 
-use crate::{Finalizer, Input, Output};
+use crate::{apply_anti_fee_sniping, Finalizer, Input, Output};
 
 const FALLBACK_SEQUENCE: bitcoin::Sequence = bitcoin::Sequence::ENABLE_LOCKTIME_NO_RBF;
 
@@ -52,6 +57,57 @@ pub struct PsbtParams {
     /// set an explicit sighash type for any input. (In that case the sighash will typically
     /// cover all of the outputs).
     pub sighash_type: Option<bitcoin::psbt::PsbtSighashType>,
+
+    /// Whether to use BIP326 anti-fee-sniping protection.
+    ///
+    /// When enabled, the transaction's nLockTime or nSequence will be set to indicate
+    /// the transaction should only be valid at or after the current block height.
+    /// This discourages miners from reorganizing recent blocks to capture fees.
+    ///
+    /// # Assumptions
+    /// - The current height is determined by the transaction's locktime (must be a block height)
+    /// - Transaction version must be >= 2 to support relative locktimes
+    ///
+    /// # Effects on Transaction
+    /// When enabled, this will modify the transaction in one of two ways:
+    /// - **nLockTime approach**: Sets `tx.lock_time` to current height (possibly with random offset)
+    /// - **nSequence approach**: Sets sequence on a randomly selected Taproot input to current
+    ///   confirmation depth (possibly with random offset)
+    ///
+    /// The choice between approaches is randomized based on BIP326 probabilities, with
+    /// certain conditions forcing nLockTime usage (unconfirmed inputs, non-Taproot inputs,
+    /// RBF disabled, etc.).
+    ///
+    /// # Error Cases
+    /// - Returns [`CreatePsbtError::InvalidLockTime`] if the locktime is not a block height
+    /// - Returns [`CreatePsbtError::UnsupportedVersion`] if transaction version is less than 2
+    ///
+    /// # Default
+    /// - Disabled by default (`false`).
+    ///
+    /// # Example
+    /// ```
+    /// use miniscript::bitcoin::absolute::{LockTime, Height};
+    /// use bdk_tx::{PsbtParams, Selection, Output};
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let params = PsbtParams {
+    ///         fallback_locktime: LockTime::from_height(800000).expect("valid height"),
+    ///         enable_anti_fee_sniping: true,
+    ///         ..PsbtParams::default()
+    ///     };
+    ///     let selection = Selection {
+    ///         inputs: vec![], /* Inputs */
+    ///         outputs: vec![], /* Outputs */
+    ///     };
+    ///     let psbt = selection.create_psbt(params)?;
+    ///     // the resulting transaction will have anti-fee-sniping applied.
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki) for more details.
+    pub enable_anti_fee_sniping: bool,
 }
 
 impl Default for PsbtParams {
@@ -62,6 +118,7 @@ impl Default for PsbtParams {
             fallback_sequence: FALLBACK_SEQUENCE,
             mandate_full_tx_for_segwit_v0: true,
             sighash_type: None,
+            enable_anti_fee_sniping: false,
         }
     }
 }
@@ -72,13 +129,17 @@ pub enum CreatePsbtError {
     /// Attempted to mix locktime types.
     LockTypeMismatch,
     /// Missing tx for legacy input.
-    MissingFullTxForLegacyInput(Input),
+    MissingFullTxForLegacyInput(Box<Input>),
     /// Missing tx for segwit v0 input.
-    MissingFullTxForSegwitV0Input(Input),
+    MissingFullTxForSegwitV0Input(Box<Input>),
     /// Psbt error.
     Psbt(bitcoin::psbt::Error),
     /// Update psbt output with descriptor error.
     OutputUpdate(miniscript::psbt::OutputUpdateError),
+    /// Invalid locktime
+    InvalidLockTime(absolute::LockTime),
+    /// Unsupported version for anti fee snipping
+    UnsupportedVersion(transaction::Version),
 }
 
 impl core::fmt::Display for CreatePsbtError {
@@ -98,6 +159,12 @@ impl core::fmt::Display for CreatePsbtError {
             CreatePsbtError::Psbt(error) => Display::fmt(&error, f),
             CreatePsbtError::OutputUpdate(output_update_error) => {
                 Display::fmt(&output_update_error, f)
+            }
+            CreatePsbtError::InvalidLockTime(locktime) => {
+                write!(f, "The locktime - {}, is invalid", locktime)
+            }
+            CreatePsbtError::UnsupportedVersion(version) => {
+                write!(f, "Unsupported version {}", version)
             }
         }
     }
@@ -128,9 +195,19 @@ impl Selection {
         acc
     }
 
-    /// Create psbt.
+    /// Create PSBT.
+    #[cfg(feature = "std")]
     pub fn create_psbt(&self, params: PsbtParams) -> Result<bitcoin::Psbt, CreatePsbtError> {
-        let mut psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
+        self.create_psbt_with_rng(params, &mut rand::thread_rng())
+    }
+
+    /// Create PSBT with `rng`.
+    pub fn create_psbt_with_rng(
+        &self,
+        params: PsbtParams,
+        rng: &mut impl RngCore,
+    ) -> Result<bitcoin::Psbt, CreatePsbtError> {
+        let mut tx = bitcoin::Transaction {
             version: params.version,
             lock_time: Self::_accumulate_max_locktime(
                 self.inputs
@@ -149,8 +226,21 @@ impl Selection {
                 })
                 .collect(),
             output: self.outputs.iter().map(|output| output.txout()).collect(),
-        })
-        .map_err(CreatePsbtError::Psbt)?;
+        };
+
+        if params.enable_anti_fee_sniping {
+            let rbf_enabled = tx.is_explicitly_rbf();
+            let current_height = match tx.lock_time {
+                LockTime::Blocks(height) => height,
+                LockTime::Seconds(_) => {
+                    return Err(CreatePsbtError::InvalidLockTime(tx.lock_time));
+                }
+            };
+
+            apply_anti_fee_sniping(&mut tx, &self.inputs, current_height, rbf_enabled, rng)?;
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(tx).map_err(CreatePsbtError::Psbt)?;
 
         for (plan_input, psbt_input) in self.inputs.iter().zip(psbt.inputs.iter_mut()) {
             if let Some(finalized_psbt_input) = plan_input.psbt_input() {
@@ -170,16 +260,16 @@ impl Selection {
                 psbt_input.non_witness_utxo = plan_input.prev_tx().cloned();
                 if psbt_input.non_witness_utxo.is_none() {
                     if witness_version.is_none() {
-                        return Err(CreatePsbtError::MissingFullTxForLegacyInput(
+                        return Err(CreatePsbtError::MissingFullTxForLegacyInput(Box::new(
                             plan_input.clone(),
-                        ));
+                        )));
                     }
                     if params.mandate_full_tx_for_segwit_v0
                         && witness_version == Some(bitcoin::WitnessVersion::V0)
                     {
-                        return Err(CreatePsbtError::MissingFullTxForSegwitV0Input(
+                        return Err(CreatePsbtError::MissingFullTxForSegwitV0Input(Box::new(
                             plan_input.clone(),
-                        ));
+                        )));
                     }
                 }
 
@@ -210,10 +300,19 @@ impl Selection {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
-    use bitcoin::{absolute, secp256k1::Secp256k1, transaction, Amount, Transaction, TxIn, TxOut};
+    use bitcoin::{
+        absolute::{self, Height, Time},
+        secp256k1::Secp256k1,
+        transaction::{self, Version},
+        Amount, ScriptBuf, Transaction, TxIn, TxOut,
+    };
     use miniscript::{plan::Assets, Descriptor, DescriptorPublicKey};
+    use rand_core::OsRng;
+
+    const TEST_DESCRIPTOR: &str = "tr([83737d5e/86h/1h/0h]tpubDDR5GgtoxS8fJyjjvdahN4VzV5DV6jtbcyvVXhEKq2XtpxjxBXmxH3r8QrNbQqHg4bJM1EGkxi7Pjfkgnui9jQWqS7kxHvX6rhUeriLDKxz/0/*)";
+    const TEST_DESCRIPTOR_PK: &str = "[83737d5e/86h/1h/0h]tpubDDR5GgtoxS8fJyjjvdahN4VzV5DV6jtbcyvVXhEKq2XtpxjxBXmxH3r8QrNbQqHg4bJM1EGkxi7Pjfkgnui9jQWqS7kxHvX6rhUeriLDKxz/0/*";
 
     #[test]
     fn test_fallback_locktime() -> anyhow::Result<()> {
@@ -227,6 +326,7 @@ mod test {
             .at_derivation_index(0)?
             .plan(&Assets::new().add(desc_pk).after(abs_locktime))
             .unwrap();
+
         let prev_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
@@ -287,5 +387,207 @@ mod test {
         }
 
         Ok(())
+    }
+
+    pub fn setup_test_input(confirmation_height: u32) -> anyhow::Result<Input> {
+        let secp = Secp256k1::new();
+        let desc = Descriptor::parse_descriptor(&secp, TEST_DESCRIPTOR)
+            .unwrap()
+            .0;
+        let def_desc = desc.at_derivation_index(0).unwrap();
+        let script_pubkey = def_desc.script_pubkey();
+        let desc_pk: DescriptorPublicKey = TEST_DESCRIPTOR_PK.parse()?;
+        let assets = Assets::new().add(desc_pk);
+        let plan = def_desc.plan(&assets).expect("failed to create plan");
+
+        let prev_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                script_pubkey,
+                value: Amount::from_sat(10_000),
+            }],
+        };
+
+        let status = crate::TxStatus {
+            height: absolute::Height::from_consensus(confirmation_height)?,
+            time: Time::from_consensus(500_000_000)?,
+        };
+
+        let input = Input::from_prev_tx(plan, prev_tx, 0, Some(status))?;
+
+        Ok(input)
+    }
+
+    #[test]
+    fn test_anti_fee_sniping_disabled() -> anyhow::Result<()> {
+        let current_height = 2_500;
+        let input = setup_test_input(2_000).unwrap();
+        let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
+        let selection = Selection {
+            inputs: vec![input],
+            outputs: vec![output],
+        };
+
+        // Disabled - default behavior is disable
+        let psbt = selection.create_psbt(PsbtParams {
+            fallback_locktime: absolute::LockTime::from_consensus(current_height),
+            fallback_sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            ..Default::default()
+        })?;
+        let tx = psbt.unsigned_tx;
+        assert_eq!(tx.lock_time.to_consensus_u32(), current_height);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_anti_fee_sniping_invalid_locktime_error() -> anyhow::Result<()> {
+        let input = setup_test_input(2_000).unwrap();
+        let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
+        let selection = Selection {
+            inputs: vec![input],
+            outputs: vec![output],
+        };
+
+        // Use time-based locktime instead of height-based
+        let result = selection.create_psbt(PsbtParams {
+            fallback_locktime: LockTime::from_consensus(500_000_000), // Time-based
+            enable_anti_fee_sniping: true,
+            ..Default::default()
+        });
+
+        assert!(
+            matches!(result, Err(CreatePsbtError::InvalidLockTime(_))),
+            "should return InvalidLockTime error for time-based locktime"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_anti_fee_sniping_protection() {
+        let current_height = 2_500;
+        let input = setup_test_input(2_000).unwrap();
+
+        let mut used_locktime = false;
+        let mut used_sequence = false;
+        let mut loops = 0;
+
+        while !used_locktime || !used_sequence {
+            let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
+            let selection = Selection {
+                inputs: vec![input.clone()],
+                outputs: vec![output],
+            };
+            let psbt = selection
+                .create_psbt(PsbtParams {
+                    fallback_locktime: absolute::LockTime::from_consensus(current_height),
+                    enable_anti_fee_sniping: true,
+                    fallback_sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    ..Default::default()
+                })
+                .unwrap();
+            let tx = psbt.unsigned_tx;
+
+            if tx.lock_time > absolute::LockTime::ZERO {
+                used_locktime = true;
+                let locktime_value = tx.lock_time.to_consensus_u32();
+                let min_height = current_height.saturating_sub(100);
+                assert!((min_height..=current_height).contains(&tx.lock_time.to_consensus_u32()));
+                assert!(locktime_value <= current_height);
+                assert!(locktime_value >= current_height.saturating_sub(100));
+            } else {
+                used_sequence = true;
+                let sequence_value = tx.input[0].sequence.to_consensus_u32();
+                let confirmations =
+                    input.confirmations(absolute::Height::from_consensus(current_height).unwrap());
+
+                let min_sequence = confirmations.saturating_sub(100);
+                assert!((min_sequence..=confirmations).contains(&sequence_value));
+                assert!(sequence_value >= 1, "Sequence must be at least 1");
+                assert!(sequence_value <= confirmations);
+                assert!(sequence_value >= confirmations.saturating_sub(100));
+            }
+
+            loops += 1;
+            assert!(
+                loops < 20,
+                "Failed to observe both behaviors within reasonable attempts"
+            );
+        }
+    }
+
+    #[test]
+    fn test_anti_fee_sniping_multiple_taproot_inputs() {
+        let current_height = 3_000;
+        let input1 = setup_test_input(2_500).unwrap();
+        let input2 = setup_test_input(2_700).unwrap();
+        let input3 = setup_test_input(3_000).unwrap();
+        let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(18_000));
+
+        let mut used_locktime = false;
+        let mut used_sequence = false;
+        let mut loops = 0;
+
+        while !used_locktime || !used_sequence {
+            let selection = Selection {
+                inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+                outputs: vec![output.clone()],
+            };
+            let psbt = selection
+                .create_psbt(PsbtParams {
+                    fallback_locktime: absolute::LockTime::from_consensus(current_height),
+                    enable_anti_fee_sniping: true,
+                    fallback_sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    ..Default::default()
+                })
+                .unwrap();
+            let tx = psbt.unsigned_tx;
+
+            if tx.lock_time > absolute::LockTime::ZERO {
+                used_locktime = true;
+            } else {
+                used_sequence = true;
+                // One of the inputs should have modified sequence
+                let has_modified_sequence = tx.input.iter().any(|txin| {
+                    txin.sequence.to_consensus_u32() > 0 && txin.sequence.to_consensus_u32() < 65535
+                });
+                assert!(has_modified_sequence);
+            }
+
+            loops += 1;
+            assert!(
+                loops < 20,
+                "Failed to observe both behaviors within reasonable attempts"
+            );
+        }
+    }
+
+    #[test]
+    fn test_anti_fee_sniping_unsupported_version_error() {
+        let confirmation_height = 800_000;
+        let input = setup_test_input(confirmation_height).unwrap();
+        let inputs = vec![input];
+        let current_height = absolute::Height::from_consensus(confirmation_height + 50).unwrap();
+
+        let mut tx = Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::from_height(current_height.to_consensus_u32()).unwrap(),
+            input: vec![TxIn {
+                previous_output: inputs[0].prev_outpoint(),
+                ..Default::default()
+            }],
+            output: vec![],
+        };
+
+        let current_height = Height::from_consensus(800_050).unwrap();
+        let result = apply_anti_fee_sniping(&mut tx, &inputs, current_height, true, &mut OsRng);
+
+        assert!(
+            matches!(result, Err(CreatePsbtError::UnsupportedVersion(_))),
+            "should return UnsupportedVersion error for version < 2"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,182 @@
+use crate::{CreatePsbtError, Input};
+use alloc::vec::Vec;
+use miniscript::bitcoin::{
+    absolute::{self, LockTime},
+    transaction::Version,
+    Sequence, Transaction,
+};
+#[cfg(feature = "std")]
+use rand::Rng;
+use rand_core::RngCore;
+
+/// Applies BIP326 anti-fee-sniping protection to a transaction.
+///
+/// Anti-fee-sniping makes transaction replay attacks less profitable by setting
+/// either nLockTime or nSequence to indicate the transaction should only be valid
+/// at or after the current block height. This discourages miners from attempting
+/// to reorganize recent blocks to claim fees from transactions.
+///
+/// # Strategy
+/// The function randomly chooses between two approaches:
+/// - **nLockTime**: Sets the transaction's lock time to approximately the current height
+/// - **nSequence**: Sets one Taproot input's sequence to approximately its confirmation depth
+///
+/// Random offsets (0-99 blocks) are applied with 10% probability to avoid creating
+/// a unique fingerprint that could identify transactions from this wallet.
+///
+/// # Parameters
+/// - `tx`: The transaction to modify
+/// - `inputs`: The inputs associated with the transaction
+/// - `current_height`: The current blockchain height (used as the base for time locks)
+/// - `rbf_enabled`: Whether Replace-By-Fee is enabled (affects strategy selection)
+/// - `rng`: Random number generator implementing `RngCore`
+///
+/// # Errors
+/// Returns an error if:
+/// - Transaction version is less than 2 [`CreatePsbtError::UnsupportedVersion`]
+///
+/// # Example
+/// ```ignore
+/// # use bdk_tx::Input;
+/// # use miniscript::bitcoin::{
+/// #     absolute::{Height, LockTime}, transaction::Version, Transaction, TxIn, TxOut, ScriptBuf, Amount
+/// # };
+/// # use rand_core::OsRng;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let inputs: Vec<Input> = vec![];
+///     let mut tx = Transaction {
+///         version: Version::TWO,
+///         lock_time: LockTime::from_height(800_000)?,
+///         input: vec![/* corresponding TxIns */],
+///         output: vec![/* your outputs */],
+///     };
+///     let current_height = Height::from_consensus(800_000)?;
+///     let mut rng = OsRng;
+///     apply_anti_fee_sniping(&mut tx, &inputs, current_height, true, &mut rng)?;
+///     // tx now has anti-fee-sniping protection applied
+///     Ok(())
+/// }
+/// ```
+///
+/// # See Also
+/// [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki)
+pub fn apply_anti_fee_sniping(
+    tx: &mut Transaction,
+    inputs: &[Input],
+    current_height: absolute::Height,
+    rbf_enabled: bool,
+    rng: &mut impl RngCore,
+) -> Result<(), CreatePsbtError> {
+    const MAX_RELATIVE_HEIGHT: u32 = 65_535;
+    const FIFTY_PERCENT_PROBABILITY_RANGE: u32 = 2;
+    const MIN_SEQUENCE_VALUE: u32 = 1;
+    const TEN_PERCENT_PROBABILITY_RANGE: u32 = 10;
+    const MAX_RANDOM_OFFSET: u32 = 100;
+
+    if tx.version < Version::TWO {
+        return Err(CreatePsbtError::UnsupportedVersion(tx.version));
+    }
+
+    // vector of input_index and associated Input ref.
+    let taproot_inputs: Vec<(usize, &Input)> = tx
+        .input
+        .iter()
+        .enumerate()
+        .filter_map(|(vin, txin)| {
+            let input = inputs
+                .iter()
+                .find(|input| input.prev_outpoint() == txin.previous_output)?;
+            if input.prev_txout().script_pubkey.is_p2tr() {
+                Some((vin, input))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Check always‐locktime conditions
+    let must_use_locktime = inputs.iter().any(|input| {
+        let confirmation = input.confirmations(current_height);
+        confirmation == 0
+            || confirmation > MAX_RELATIVE_HEIGHT
+            || !input.prev_txout().script_pubkey.is_p2tr()
+    });
+
+    let use_locktime = !rbf_enabled
+        || must_use_locktime
+        || taproot_inputs.is_empty()
+        || random_probability(rng, FIFTY_PERCENT_PROBABILITY_RANGE);
+
+    if use_locktime {
+        // Use nLockTime
+        let mut locktime = current_height.to_consensus_u32();
+
+        if random_probability(rng, TEN_PERCENT_PROBABILITY_RANGE) {
+            let random_offset = random_range(rng, MAX_RANDOM_OFFSET);
+            locktime = locktime.saturating_sub(random_offset);
+        }
+
+        let new_locktime = LockTime::from_height(locktime).expect("must be valid Height");
+
+        tx.lock_time = new_locktime;
+    } else {
+        // Use Sequence
+        tx.lock_time = LockTime::ZERO;
+        let random_index = random_range(rng, taproot_inputs.len() as u32);
+        let (input_index, input) = taproot_inputs[random_index as usize];
+        let confirmation = input.confirmations(current_height);
+
+        let mut sequence_value = confirmation;
+        if random_probability(rng, TEN_PERCENT_PROBABILITY_RANGE) {
+            let random_offset = random_range(rng, MAX_RANDOM_OFFSET);
+            sequence_value = sequence_value
+                .saturating_sub(random_offset)
+                .max(MIN_SEQUENCE_VALUE);
+        }
+
+        tx.input[input_index].sequence = Sequence(sequence_value);
+    }
+
+    Ok(())
+}
+
+/// Returns true with probability 1/n.
+#[cfg(feature = "std")]
+fn random_probability(rng: &mut impl RngCore, n: u32) -> bool {
+    rng.gen_bool(1.0 / n as f64)
+}
+
+/// Returns true with probability 1/n.
+///
+/// This `no-std` implementation avoids depending on the full `rand` crate,
+/// keeping the dependency tree minimal while supporting `no-std` environments
+/// through `rand_core` alone.
+#[cfg(not(feature = "std"))]
+fn random_probability(rng: &mut impl RngCore, n: u32) -> bool {
+    random_range(rng, n) == 0
+}
+
+/// Returns a random value in the range [0, n).
+#[cfg(feature = "std")]
+fn random_range(rng: &mut impl RngCore, n: u32) -> u32 {
+    rng.gen_range(0..n)
+}
+
+/// Returns a random value in the range [0, n) using unbiased sampling.
+///
+/// This `no-std` implementation uses rejection sampling to ensure uniform
+/// distribution and avoid modulo bias, without depending on the full `rand` crate.
+/// This keeps the dependency tree minimal while supporting `no-std` environments
+/// through `rand_core` alone.
+#[cfg(not(feature = "std"))]
+fn random_range(rng: &mut impl RngCore, n: u32) -> u32 {
+    let threshold = n.wrapping_neg() % n;
+
+    loop {
+        let value = rng.next_u32();
+        if value >= threshold {
+            return value % n;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements Anti-Fee-Sniping with randomization as discussed in issue #4 

## Notes to the reviewers
The implementation adds randomization to anti-fee-sniping behavior:

1. Uses a 50/50 chance to choose between nLockTime and nSequence (when possible)
2. Adds a 10% chance to set either value further back in time (by a random value between 0-99)
3. Detects taproot inputs and their confirmation status



## Changelog notice

### Changed
- `CreatePsbtError::MissingFullTxForLegacyInput` and `CreatePsbtError::MissingFullTxForSegwitV0Input` now wrap `Input` in `Box` (breaking change)

### Added
- `PsbtParams::enable_anti_fee_sniping` field for BIP326 anti-fee-sniping protection
- `CreatePsbtError::InvalidLockTime` and `CreatePsbtError::UnsupportedVersion` error variants
- `Selection::create_psbt_with_rng` method for custom RNG



* [x] I've signed all my commits
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added docs for the new feature

Closes #4 
