### PR TITLE
feat(selector): allow multiple change sources with ChangeDescriptor

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -74,6 +74,15 @@ impl From<(DefiniteDescriptor, Amount)> for Output {
     }
 }
 
+impl From<(ScriptSource, Amount)> for Output {
+    fn from((src, value): (ScriptSource, Amount)) -> Self {
+        match src {
+            ScriptSource::Descriptor(desc) => Self::with_descriptor(*desc, value),
+            ScriptSource::Script(s) => Self::with_script(s, value),
+        }
+    }
+}
+
 impl Output {
     /// From script
     pub fn with_script(script: ScriptBuf, value: Amount) -> Self {


### PR DESCRIPTION
**Description**

Previously, the `change_descriptor` field only accepted a definite descriptor to derive the change output script pubkey. This worked for most cases but failed for scenarios - such as silent payments - where a definite descriptor is not yet available.

To address this, introduce the `ChangeDescriptor` enum, which supports:

- The standard case of providing a definite descriptor.
- An alternative where the script pubkey and its maximum satisfaction weight can be specified directly.

This makes change output generation flexible enough to handle both standard and exceptional workflows.

Fixes #17 

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] I ran `cargo +nigthly fmt` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
