### PR TITLE
feat(selection)!: Add member `PsbtParams::sighash_type`

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -44,6 +44,14 @@ pub struct PsbtParams {
     ///
     /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
     pub mandate_full_tx_for_segwit_v0: bool,
+
+    /// Sighash type to be used for each input.
+    ///
+    /// This option only applies to [`Input`]s that include a plan, as otherwise the given PSBT
+    /// input can be expected to set a specific sighash type. Defaults to `None` which will not
+    /// set an explicit sighash type for any input. (In that case the sighash will typically
+    /// cover all of the outputs).
+    pub sighash_type: Option<bitcoin::psbt::PsbtSighashType>,
 }
 
 impl Default for PsbtParams {
@@ -53,6 +61,7 @@ impl Default for PsbtParams {
             fallback_locktime: absolute::LockTime::ZERO,
             fallback_sequence: FALLBACK_SEQUENCE,
             mandate_full_tx_for_segwit_v0: true,
+            sighash_type: None,
         }
     }
 }
@@ -179,6 +188,9 @@ impl Selection {
                         ));
                     }
                 }
+
+                psbt_input.sighash_type = params.sighash_type;
+
                 continue;
             }
             unreachable!("input candidate must either have finalized psbt input or plan");


### PR DESCRIPTION
This adds a new field `sighash_type` to `PsbtParams`. The option only applies to inputs that include a plan, as otherwise the given PSBT input can be expected to set a specific sighash type. The default is `None` which will not set an explicit sighash type for any input. In that case the sighash will typically cover all of the outputs.