### PR TITLE
ci: pin `home` to 0.5.11

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -3,4 +3,4 @@
 set -x
 set -euo pipefail
 
-echo "MSRV 1.85.0 - no dependency pins needed"
+cargo update -p home --precise "0.5.11"


### PR DESCRIPTION
Pin `home` dependency to `0.5.11` to build with Rust 1.85.0.