### PR TITLE
selector!: Swap `ChangePolicyType` for `bdk_coin_select::ChangePolicy`

### DIFF
--- a/examples/common.rs
+++ b/examples/common.rs
@@ -136,7 +136,7 @@ impl Wallet {
     }
 
     /// Computes the weight of a change output plus the future weight to spend it.
-    pub fn change_weight(&self) -> DrainWeights {
+    pub fn drain_weights(&self) -> DrainWeights {
         // Get descriptor of change keychain at a derivation index.
         let desc = self
             .graph
@@ -176,7 +176,7 @@ impl Wallet {
             .expect("spk should exist in wallet");
         ChangePolicy {
             min_value: spk_0.minimal_non_dust().to_sat(),
-            drain_weights: self.change_weight(),
+            drain_weights: self.drain_weights(),
         }
     }
 

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -4,7 +4,7 @@ use bdk_bitcoind_rpc::{Emitter, NO_EXPECTED_MEMPOOL_TXIDS};
 use bdk_chain::{
     bdk_core, Anchor, Balance, CanonicalizationParams, ChainPosition, ConfirmationBlockTime,
 };
-use bdk_coin_select::DrainWeights;
+use bdk_coin_select::{ChangePolicy, DrainWeights};
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{CanonicalUnspents, Input, InputCandidates, RbfParams, TxStatus, TxWithStatus};
 use bitcoin::{absolute, Address, Amount, BlockHash, OutPoint, Transaction, TxOut, Txid};
@@ -164,6 +164,19 @@ impl Wallet {
             output_weight,
             spend_weight,
             n_outputs: 1,
+        }
+    }
+
+    /// Get the default change policy for this wallet.
+    pub fn change_policy(&self) -> ChangePolicy {
+        let spk_0 = self
+            .graph
+            .index
+            .spk_at_index(INTERNAL, 0)
+            .expect("spk should exist in wallet");
+        ChangePolicy {
+            min_value: spk_0.minimal_non_dust().to_sat(),
+            drain_weights: self.change_weight(),
         }
     }
 

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,7 +1,7 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
     filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, ChangePolicyType,
-    Output, PsbtParams, ScriptSource, SelectorParams, Signer,
+    FeeTarget, Output, PsbtParams, ScriptSource, SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate, Sequence};
 use miniscript::Descriptor;
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
         .into_selection(
             selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
             SelectorParams::new(
-                FeeRate::from_sat_per_vb_unchecked(10),
+                FeeTarget::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
                 vec![Output::with_script(
                     recipient_addr.script_pubkey(),
                     Amount::from_sat(21_000_000),
@@ -129,7 +129,7 @@ fn main() -> anyhow::Result<()> {
                 SelectorParams {
                     // This is just a lower-bound feerate. The actual result will be much higher to
                     // satisfy mempool-replacement policy.
-                    target_feerate: FeeRate::from_sat_per_vb_unchecked(1),
+                    target_feerate: FeeTarget::FeeRate(FeeRate::from_sat_per_vb_unchecked(1)),
                     // We cancel the tx by specifying no target outputs. This way, all excess returns
                     // to our change output (unless if the prevouts picked are so small that it will
                     // be less wasteful to have no output, however that will not be a valid tx).

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -62,7 +62,6 @@ fn main() -> anyhow::Result<()> {
                 )],
                 ScriptSource::Descriptor(Box::new(internal.at_derivation_index(0)?)),
                 wallet.change_policy(),
-                wallet.change_weight(),
             ),
         )?;
 
@@ -139,7 +138,6 @@ fn main() -> anyhow::Result<()> {
                         internal.at_derivation_index(1)?,
                     )),
                     change_policy: wallet.change_policy(),
-                    change_weight: wallet.change_weight(),
                     // This ensures that we satisfy mempool-replacement policy rules 4 and 6.
                     replace: Some(rbf_params),
                 },

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,7 +1,7 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, ChangePolicyType,
-    FeeTarget, Output, PsbtParams, ScriptSource, SelectorParams, Signer,
+    filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeTarget, Output,
+    PsbtParams, ScriptSource, SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate, Sequence};
 use miniscript::Descriptor;
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
                     Amount::from_sat(21_000_000),
                 )],
                 ScriptSource::Descriptor(Box::new(internal.at_derivation_index(0)?)),
-                ChangePolicyType::NoDustAndLeastWaste { longterm_feerate },
+                wallet.change_policy(),
                 wallet.change_weight(),
             ),
         )?;
@@ -138,7 +138,7 @@ fn main() -> anyhow::Result<()> {
                     change_script: ScriptSource::Descriptor(Box::new(
                         internal.at_derivation_index(1)?,
                     )),
-                    change_policy: ChangePolicyType::NoDustAndLeastWaste { longterm_feerate },
+                    change_policy: wallet.change_policy(),
                     change_weight: wallet.change_weight(),
                     // This ensures that we satisfy mempool-replacement policy rules 4 and 6.
                     replace: Some(rbf_params),

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,6 +1,6 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeTarget, Output,
+    filter_unspendable_now, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeStrategy, Output,
     PsbtParams, ScriptSource, SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate, Sequence};
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
         .into_selection(
             selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
             SelectorParams::new(
-                FeeTarget::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
+                FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
                 vec![Output::with_script(
                     recipient_addr.script_pubkey(),
                     Amount::from_sat(21_000_000),
@@ -128,7 +128,7 @@ fn main() -> anyhow::Result<()> {
                 SelectorParams {
                     // This is just a lower-bound feerate. The actual result will be much higher to
                     // satisfy mempool-replacement policy.
-                    target_feerate: FeeTarget::FeeRate(FeeRate::from_sat_per_vb_unchecked(1)),
+                    fee_strategy: FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(1)),
                     // We cancel the tx by specifying no target outputs. This way, all excess returns
                     // to our change output (unless if the prevouts picked are so small that it will
                     // be less wasteful to have no output, however that will not be a valid tx).

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,6 +1,4 @@
-use bdk_coin_select::{
-    ChangePolicy, DrainWeights, InsufficientFunds, Replace, Target, TargetFee, TargetOutputs,
-};
+use bdk_coin_select::{ChangePolicy, InsufficientFunds, Replace, Target, TargetFee, TargetOutputs};
 use bitcoin::{Amount, FeeRate, Transaction, Weight};
 use miniscript::bitcoin;
 
@@ -46,10 +44,6 @@ pub struct SelectorParams {
 
     /// The policy to determine whether we create a change output.
     pub change_policy: ChangePolicy,
-
-    // TODO: Remove this since the drain weights are now represented in the change policy.
-    /// Weight of the change output plus the future weight to spend the change
-    pub change_weight: DrainWeights,
 
     /// Params for replacing tx(s).
     pub replace: Option<RbfParams>,
@@ -151,14 +145,12 @@ impl SelectorParams {
         target_outputs: Vec<Output>,
         change_script: ScriptSource,
         change_policy: ChangePolicy,
-        change_weight: DrainWeights,
     ) -> Self {
         Self {
             target_feerate,
             target_outputs,
             change_script,
             change_policy,
-            change_weight,
             replace: None,
         }
     }
@@ -380,7 +372,6 @@ mod tests {
             target_outputs.clone(),
             change_script(),
             change_policy(),
-            DrainWeights::default(),
         );
 
         // With fee rate
@@ -389,7 +380,6 @@ mod tests {
             target_outputs,
             change_script(),
             change_policy(),
-            DrainWeights::default(),
         );
 
         let target_absolute = params_absolute.to_cs_target();


### PR DESCRIPTION
## Description

Fix #29 by removing `ChangePolicyType` from `SelectorParams` in favor of `bdk_coin_select::ChangePolicy`. The idea is that this affords maximum flexibility when defining the change policy.

Builds on #31 which implements absolute fee targeting. h/t aagbotemi. A test `test_absolute_fee_vs_feerate_target_value` is added that checks the expected `Target` is constructed based on the chosen `FeeStrategy`.

## Changelog

### Added

- selector: Added `FeeStrategy` enum which defines the fee target as either a feerate or fee amount.

### Changed

**BREAKING**

- `SelectorParams::target_feerate` field is changed to `fee_strategy`.
- `SelectorParams::change_policy` field is changed to have type `bdk_coin_select::ChangePolicy`.
- `SelectorParams::new` is changed to accept the `fee_strategy` and `change_policy` as inputs.

### Removed

- `SelectorParams::change_weight` field is removed now that the change weights are represented in the actual change policy.
- Removed `SelectorParams::to_cs_change_policy` as the conversion is no longer necessary.
- Removed `ChangePolicyType` enum to allow the user to construct the intended `ChangePolicy`.
