### PR TITLE
refactor!: Remove FeeStrategy add ChangeScript and improve SelectorParams

### DIFF
--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -80,11 +80,8 @@ fn main() -> anyhow::Result<()> {
                         recipient_addr.script_pubkey(),
                         Amount::from_sat(50_000_000),
                     )],
-                    bdk_tx::ChangeScript::Descriptor(Box::new(internal.at_derivation_index(0)?)),
-                    bdk_tx::ChangePolicy::NoDustLeastWaste {
-                        longterm_feerate,
-                        min_value: None,
-                    },
+                    bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
+                    bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
                 ),
             )?;
 

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeStrategy, Output,
-    PsbtParams, ScriptSource, SelectorParams,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtParams,
+    SelectorParams,
 };
 use bitcoin::{absolute::LockTime, key::Secp256k1, Amount, FeeRate, Sequence};
 use miniscript::Descriptor;
@@ -75,13 +75,16 @@ fn main() -> anyhow::Result<()> {
             .into_selection(
                 selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
                 SelectorParams::new(
-                    FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
+                    FeeRate::from_sat_per_vb_unchecked(10),
                     vec![Output::with_script(
                         recipient_addr.script_pubkey(),
                         Amount::from_sat(50_000_000),
                     )],
-                    ScriptSource::Descriptor(Box::new(internal.at_derivation_index(0)?)),
-                    wallet.change_policy(),
+                    bdk_tx::ChangeScript::Descriptor(Box::new(internal.at_derivation_index(0)?)),
+                    bdk_tx::ChangePolicy::NoDustLeastWaste {
+                        longterm_feerate,
+                        min_value: None,
+                    },
                 ),
             )?;
 

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -74,15 +74,18 @@ fn main() -> anyhow::Result<()> {
             .filter(filter_unspendable(tip_height, Some(tip_time)))
             .into_selection(
                 selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
-                SelectorParams::new(
-                    FeeRate::from_sat_per_vb_unchecked(10),
-                    vec![Output::with_script(
-                        recipient_addr.script_pubkey(),
-                        Amount::from_sat(50_000_000),
-                    )],
-                    bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
-                    bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
-                ),
+                SelectorParams {
+                    // For waste optimization when deciding change.
+                    change_longterm_feerate: Some(longterm_feerate),
+                    ..SelectorParams::new(
+                        FeeRate::from_sat_per_vb_unchecked(10),
+                        vec![Output::with_script(
+                            recipient_addr.script_pubkey(),
+                            Amount::from_sat(50_000_000),
+                        )],
+                        bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
+                    )
+                },
             )?;
 
         let fallback_locktime: LockTime = LockTime::from_consensus(tip_height.to_consensus_u32());

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -4,12 +4,11 @@ use bdk_bitcoind_rpc::{Emitter, NO_EXPECTED_MEMPOOL_TXIDS};
 use bdk_chain::{
     bdk_core, Anchor, Balance, CanonicalizationParams, ChainPosition, ConfirmationBlockTime,
 };
-use bdk_coin_select::{ChangePolicy, DrainWeights};
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
     CanonicalUnspents, ConfirmationStatus, Input, InputCandidates, RbfParams, TxWithStatus,
 };
-use bitcoin::{absolute, Address, Amount, BlockHash, OutPoint, Transaction, TxOut, Txid};
+use bitcoin::{absolute, Address, BlockHash, OutPoint, Transaction, Txid};
 use miniscript::{
     plan::{Assets, Plan},
     Descriptor, DescriptorPublicKey, ForEachKey,
@@ -141,51 +140,6 @@ impl Wallet {
                 CanonicalizationParams::default(),
             )
             .map(|c_tx| (c_tx.tx_node.tx, status_from_position(c_tx.chain_position)))
-    }
-
-    /// Computes the weight of a change output plus the future weight to spend it.
-    pub fn drain_weights(&self) -> DrainWeights {
-        // Get descriptor of change keychain at a derivation index.
-        let desc = self
-            .graph
-            .index
-            .get_descriptor(INTERNAL)
-            .unwrap()
-            .at_derivation_index(0)
-            .unwrap();
-
-        // Compute the weight of a change output for this wallet.
-        let output_weight = TxOut {
-            script_pubkey: desc.script_pubkey(),
-            value: Amount::ZERO,
-        }
-        .weight()
-        .to_wu();
-
-        // The spend weight is the default input weight plus the plan satisfaction weight
-        // (this code assumes that we're only dealing with segwit transactions).
-        let plan = desc.plan(&self.assets()).expect("failed to create Plan");
-        let spend_weight =
-            bitcoin::TxIn::default().segwit_weight().to_wu() + plan.satisfaction_weight() as u64;
-
-        DrainWeights {
-            output_weight,
-            spend_weight,
-            n_outputs: 1,
-        }
-    }
-
-    /// Get the default change policy for this wallet.
-    pub fn change_policy(&self) -> ChangePolicy {
-        let spk_0 = self
-            .graph
-            .index
-            .spk_at_index(INTERNAL, 0)
-            .expect("spk should exist in wallet");
-        ChangePolicy {
-            min_value: spk_0.minimal_non_dust().to_sat(),
-            drain_weights: self.drain_weights(),
-        }
     }
 
     pub fn all_candidates(&self) -> bdk_tx::InputCandidates {

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -60,11 +60,8 @@ fn main() -> anyhow::Result<()> {
                     recipient_addr.script_pubkey(),
                     Amount::from_sat(21_000_000),
                 )],
-                bdk_tx::ChangeScript::Descriptor(Box::new(internal.at_derivation_index(0)?)),
-                bdk_tx::ChangePolicy::NoDustLeastWaste {
-                    longterm_feerate,
-                    min_value: None,
-                },
+                bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
+                bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
             ),
         )?;
 
@@ -137,13 +134,10 @@ fn main() -> anyhow::Result<()> {
                     // be less wasteful to have no output, however that will not be a valid tx).
                     // If you only want to fee bump, put the original txs' recipients here.
                     target_outputs: vec![],
-                    change_script: bdk_tx::ChangeScript::Descriptor(Box::new(
+                    change_script: bdk_tx::ChangeScript::from_descriptor(
                         internal.at_derivation_index(1)?,
-                    )),
-                    change_policy: bdk_tx::ChangePolicy::NoDustLeastWaste {
-                        longterm_feerate,
-                        min_value: None,
-                    },
+                    ),
+                    change_policy: bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
                     // This ensures that we satisfy mempool-replacement policy rules 4 and 6.
                     replace: Some(rbf_params),
                     dust_relay_feerate: None,

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,7 +1,7 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, FeeStrategy, Output,
-    PsbtParams, ScriptSource, SelectorParams, Signer,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtParams,
+    SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate, Sequence};
 use miniscript::Descriptor;
@@ -55,13 +55,16 @@ fn main() -> anyhow::Result<()> {
         .into_selection(
             selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
             SelectorParams::new(
-                FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(10)),
+                FeeRate::from_sat_per_vb_unchecked(10),
                 vec![Output::with_script(
                     recipient_addr.script_pubkey(),
                     Amount::from_sat(21_000_000),
                 )],
-                ScriptSource::Descriptor(Box::new(internal.at_derivation_index(0)?)),
-                wallet.change_policy(),
+                bdk_tx::ChangeScript::Descriptor(Box::new(internal.at_derivation_index(0)?)),
+                bdk_tx::ChangePolicy::NoDustLeastWaste {
+                    longterm_feerate,
+                    min_value: None,
+                },
             ),
         )?;
 
@@ -128,18 +131,22 @@ fn main() -> anyhow::Result<()> {
                 SelectorParams {
                     // This is just a lower-bound feerate. The actual result will be much higher to
                     // satisfy mempool-replacement policy.
-                    fee_strategy: FeeStrategy::FeeRate(FeeRate::from_sat_per_vb_unchecked(1)),
+                    target_feerate: FeeRate::from_sat_per_vb_unchecked(1),
                     // We cancel the tx by specifying no target outputs. This way, all excess returns
                     // to our change output (unless if the prevouts picked are so small that it will
                     // be less wasteful to have no output, however that will not be a valid tx).
                     // If you only want to fee bump, put the original txs' recipients here.
                     target_outputs: vec![],
-                    change_script: ScriptSource::Descriptor(Box::new(
+                    change_script: bdk_tx::ChangeScript::Descriptor(Box::new(
                         internal.at_derivation_index(1)?,
                     )),
-                    change_policy: wallet.change_policy(),
+                    change_policy: bdk_tx::ChangePolicy::NoDustLeastWaste {
+                        longterm_feerate,
+                        min_value: None,
+                    },
                     // This ensures that we satisfy mempool-replacement policy rules 4 and 6.
                     replace: Some(rbf_params),
+                    dust_relay_feerate: None,
                 },
             )?;
 

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -54,15 +54,18 @@ fn main() -> anyhow::Result<()> {
         .filter(filter_unspendable(tip_height, Some(tip_mtp)))
         .into_selection(
             selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
-            SelectorParams::new(
-                FeeRate::from_sat_per_vb_unchecked(10),
-                vec![Output::with_script(
-                    recipient_addr.script_pubkey(),
-                    Amount::from_sat(21_000_000),
-                )],
-                bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
-                bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
-            ),
+            SelectorParams {
+                // For waste-optimization when deciding change.
+                change_longterm_feerate: Some(longterm_feerate),
+                ..SelectorParams::new(
+                    FeeRate::from_sat_per_vb_unchecked(10),
+                    vec![Output::with_script(
+                        recipient_addr.script_pubkey(),
+                        Amount::from_sat(21_000_000),
+                    )],
+                    bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
+                )
+            },
         )?;
 
     let mut psbt = selection.create_psbt(PsbtParams {
@@ -137,10 +140,12 @@ fn main() -> anyhow::Result<()> {
                     change_script: bdk_tx::ChangeScript::from_descriptor(
                         internal.at_derivation_index(1)?,
                     ),
-                    change_policy: bdk_tx::ChangePolicy::no_dust_least_waste(longterm_feerate),
+                    // For waste optimization when deciding change.
+                    change_longterm_feerate: Some(longterm_feerate),
+                    change_min_value: None,
+                    change_dust_relay_feerate: None,
                     // This ensures that we satisfy mempool-replacement policy rules 4 and 6.
                     replace: Some(rbf_params),
-                    dust_relay_feerate: None,
                 },
             )?;
 

--- a/src/input_candidates.rs
+++ b/src/input_candidates.rs
@@ -8,7 +8,7 @@ use miniscript::bitcoin;
 
 use crate::collections::{BTreeMap, HashSet};
 use crate::{
-    cs_feerate, CannotMeetTarget, Input, InputGroup, Selection, Selector, SelectorError,
+    CannotMeetTarget, FeeRateExt, Input, InputGroup, Selection, Selector, SelectorError,
     SelectorParams,
 };
 
@@ -291,10 +291,10 @@ pub fn selection_algorithm_lowest_fee_bnb(
     longterm_feerate: FeeRate,
     max_rounds: usize,
 ) -> impl FnMut(&mut Selector) -> Result<(), NoBnbSolution> {
-    let long_term_feerate = cs_feerate(longterm_feerate);
+    let long_term_feerate = longterm_feerate.into_cs_feerate();
     move |selector| {
         let target = selector.target();
-        let change_policy = selector.change_policy();
+        let change_policy = selector.cs_change_policy();
         selector
             .inner_mut()
             .run_bnb(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,15 @@ pub(crate) mod collections {
 
 /// Definite descriptor.
 pub type DefiniteDescriptor = Descriptor<DefiniteDescriptorKey>;
+
+/// Extension trait for converting [`bitcoin::FeeRate`] to [`bdk_coin_select::FeeRate`].
+pub trait FeeRateExt {
+    /// Convert to a [`bdk_coin_select::FeeRate`].
+    fn into_cs_feerate(self) -> bdk_coin_select::FeeRate;
+}
+
+impl FeeRateExt for bitcoin::FeeRate {
+    fn into_cs_feerate(self) -> bdk_coin_select::FeeRate {
+        bdk_coin_select::FeeRate::from_sat_per_wu(self.to_sat_per_kwu() as f32 / 1000.0)
+    }
+}

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -2,7 +2,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 
-use bdk_coin_select::FeeRate;
 use miniscript::bitcoin;
 use miniscript::bitcoin::{
     absolute::{self, LockTime},
@@ -14,10 +13,6 @@ use rand_core::RngCore;
 use crate::{apply_anti_fee_sniping, Finalizer, Input, Output};
 
 const FALLBACK_SEQUENCE: bitcoin::Sequence = bitcoin::Sequence::ENABLE_LOCKTIME_NO_RBF;
-
-pub(crate) fn cs_feerate(feerate: bitcoin::FeeRate) -> bdk_coin_select::FeeRate {
-    FeeRate::from_sat_per_wu(feerate.to_sat_per_kwu() as f32 / 1000.0)
-}
 
 /// Final selection of inputs and outputs.
 #[derive(Debug, Clone)]

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -45,16 +45,24 @@ pub struct SelectorParams {
     /// this. For descriptors it is computed automatically; for raw scripts it must be provided.
     pub change_script: ChangeScript,
 
-    /// The policy to determine whether we create a change output.
-    pub change_policy: ChangePolicy,
-
-    /// Params for replacing tx(s).
-    pub replace: Option<RbfParams>,
-
     /// Dust relay feerate used to calculate the dust threshold for change outputs.
     ///
     /// If `None`, defaults to 3 sat/vB (the Bitcoin Core default for `-dustrelayfee`).
-    pub dust_relay_feerate: Option<FeeRate>,
+    pub change_dust_relay_feerate: Option<FeeRate>,
+
+    /// Minimum change value.
+    ///
+    /// A change value below this is forgone as fee. `None` means only the dust threshold applies.
+    pub change_min_value: Option<Amount>,
+
+    /// Long-term feerate for waste optimization when deciding whether to include change.
+    ///
+    /// `None` means no waste optimization - just enforce `change_min_value` (if specified) and the
+    /// dust threshold.
+    pub change_longterm_feerate: Option<FeeRate>,
+
+    /// Params for replacing tx(s).
+    pub replace: Option<RbfParams>,
 }
 
 /// Source of the change output script and its spending cost.
@@ -75,8 +83,8 @@ pub enum ChangeScript {
         /// [`Plan::satisfaction_weight`](miniscript::plan::Plan::satisfaction_weight) and is used
         /// by coin selection to estimate the cost of spending the change output.
         ///
-        /// Can be `None` if the change policy does not require waste calculations.
-        satisfaction_weight: Option<Weight>,
+        /// Can be `Weight::ZERO` if `SelectorParams::change_longterm_feerate` is unspecified.
+        satisfaction_weight: Weight,
     },
     /// A definite descriptor from which the script and satisfaction weight are both derived.
     Descriptor {
@@ -118,7 +126,7 @@ impl ChangeScript {
     }
 
     /// Create from a raw script.
-    pub fn from_script(script: ScriptBuf, satisfaction_weight: Option<Weight>) -> Self {
+    pub fn from_script(script: ScriptBuf, satisfaction_weight: Weight) -> Self {
         Self::Script {
             script,
             satisfaction_weight,
@@ -140,7 +148,7 @@ impl ChangeScript {
             ChangeScript::Script {
                 satisfaction_weight,
                 ..
-            } => satisfaction_weight.ok_or(SelectorError::MissingSatisfactionWeight),
+            } => Ok(*satisfaction_weight),
             ChangeScript::Descriptor {
                 descriptor,
                 satisfaction_assets,
@@ -154,56 +162,6 @@ impl ChangeScript {
                     .max_weight_to_satisfy()
                     .map_err(SelectorError::Miniscript),
             },
-        }
-    }
-}
-
-/// Policy for deciding whether to create a change output.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ChangePolicy {
-    /// Create a change output as long as it is not dust.
-    NoDust {
-        /// Minimum change value. If set, change below this value is forgone as fee.
-        min_value: Option<Amount>,
-    },
-    /// Create a change output as long as it is not dust and doing so reduces waste.
-    NoDustLeastWaste {
-        /// Long-term feerate estimate used to evaluate the future cost of spending the change.
-        longterm_feerate: FeeRate,
-        /// Minimum change value. If set, change below this value is forgone as fee.
-        min_value: Option<Amount>,
-    },
-}
-
-impl ChangePolicy {
-    /// Create a policy that avoids dust change outputs.
-    pub fn no_dust() -> Self {
-        Self::NoDust { min_value: None }
-    }
-
-    /// Create a policy that avoids dust and minimizes waste.
-    pub fn no_dust_least_waste(longterm_feerate: FeeRate) -> Self {
-        Self::NoDustLeastWaste {
-            longterm_feerate,
-            min_value: None,
-        }
-    }
-
-    /// Set a minimum change value. Change below this amount is forgone as fee.
-    #[must_use]
-    pub fn min_value(mut self, min_value: Amount) -> Self {
-        match &mut self {
-            Self::NoDust { min_value: mv, .. } => *mv = Some(min_value),
-            Self::NoDustLeastWaste { min_value: mv, .. } => *mv = Some(min_value),
-        }
-        self
-    }
-
-    fn considers_waste(&self) -> bool {
-        match self {
-            ChangePolicy::NoDust { .. } => false,
-            ChangePolicy::NoDustLeastWaste { .. } => true,
         }
     }
 }
@@ -285,15 +243,15 @@ impl SelectorParams {
         target_feerate: FeeRate,
         target_outputs: Vec<Output>,
         change_script: ChangeScript,
-        change_policy: ChangePolicy,
     ) -> Self {
         Self {
             target_feerate,
             target_outputs,
             change_script,
-            change_policy,
+            change_min_value: None,
+            change_longterm_feerate: None,
             replace: None,
-            dust_relay_feerate: None,
+            change_dust_relay_feerate: None,
         }
     }
 
@@ -320,16 +278,13 @@ impl SelectorParams {
     ///
     /// # Errors
     ///
-    /// Returns [`SelectorError::MissingSatisfactionWeight`] if the change script is a raw script
-    /// without a satisfaction weight and the change policy requires waste calculations.
-    ///
     /// Returns [`SelectorError::InsufficientAssets`] if the provided assets cannot satisfy the
     /// change descriptor.
     ///
     /// Returns [`SelectorError::Miniscript`] if the change descriptor is inherently unsatisfiable.
     pub fn to_cs_change_policy(&self) -> Result<bdk_coin_select::ChangePolicy, SelectorError> {
         let change_script = self.change_script.source().script();
-        let min_non_dust = self.dust_relay_feerate.map_or_else(
+        let min_non_dust = self.change_dust_relay_feerate.map_or_else(
             || change_script.minimal_non_dust(),
             |r| change_script.minimal_non_dust_custom(r),
         );
@@ -342,32 +297,28 @@ impl SelectorParams {
                 };
                 temp_txout.weight().to_wu()
             },
-            spend_weight: if self.change_policy.considers_waste() {
-                // This code assumes that the change spend transaction is segwit.
-                bitcoin::TxIn::default().segwit_weight().to_wu()
-                    + self.change_script.satisfaction_weight()?.to_wu()
-            } else {
-                // Spend weight is not needed.
-                0
-            },
+            // This code assumes that the change spend transaction is segwit.
+            spend_weight: bitcoin::TxIn::default().segwit_weight().to_wu()
+                + self.change_script.satisfaction_weight()?.to_wu(),
             n_outputs: 1,
         };
 
-        Ok(match self.change_policy {
-            ChangePolicy::NoDust { min_value } => bdk_coin_select::ChangePolicy::min_value(
-                change_weights,
-                min_non_dust.max(min_value.unwrap_or(Amount::ZERO)).to_sat(),
-            ),
-            ChangePolicy::NoDustLeastWaste {
-                longterm_feerate,
-                min_value,
-            } => bdk_coin_select::ChangePolicy::min_value_and_waste(
-                change_weights,
-                min_non_dust.max(min_value.unwrap_or(Amount::ZERO)).to_sat(),
-                self.target_feerate.into_cs_feerate(),
-                longterm_feerate.into_cs_feerate(),
-            ),
-        })
+        let min_value = min_non_dust
+            .max(self.change_min_value.unwrap_or(Amount::ZERO))
+            .to_sat();
+
+        Ok(
+            if let Some(longterm_feerate) = self.change_longterm_feerate {
+                bdk_coin_select::ChangePolicy::min_value_and_waste(
+                    change_weights,
+                    min_value,
+                    self.target_feerate.into_cs_feerate(),
+                    longterm_feerate.into_cs_feerate(),
+                )
+            } else {
+                bdk_coin_select::ChangePolicy::min_value(change_weights, min_value)
+            },
+        )
     }
 }
 
@@ -394,9 +345,6 @@ pub enum SelectorError {
     Miniscript(miniscript::Error),
     /// Meeting the target is not possible with the input candidates.
     CannotMeetTarget(CannotMeetTarget),
-    /// The change policy requires a satisfaction weight, but none was provided for the raw change
-    /// script.
-    MissingSatisfactionWeight,
     /// The provided assets cannot satisfy the change descriptor.
     InsufficientAssets,
 }
@@ -406,10 +354,6 @@ impl fmt::Display for SelectorError {
         match self {
             Self::Miniscript(err) => write!(f, "{err}"),
             Self::CannotMeetTarget(err) => write!(f, "{err}"),
-            Self::MissingSatisfactionWeight => write!(
-                f,
-                "change policy requires satisfaction weight, but none was provided for the raw script"
-            ),
             Self::InsufficientAssets => {
                 write!(f, "provided assets cannot satisfy the change descriptor")
             }


### PR DESCRIPTION
Fixes #40 
Fixes #42

## Summary

This PR fixes two issues with `SelectorParams`:

**1. Redundant satisfaction weight (invalid representation)**

`SelectorParams` previously had two independent fields that could both specify the change output's satisfaction weight:

- `change_script: ScriptSource` — when this is the `Descriptor` variant, the satisfaction weight is derivable from the descriptor via `max_weight_to_satisfy`.
- `change_policy: ChangePolicy` — also encodes the satisfaction weight (the spend cost of the change output).

Nothing enforced that these agreed with each other, so callers could silently provide inconsistent values.

Fixed by introducing **`ChangeScript`**, which bundles a raw script with an optional `satisfaction_weight`, or holds a `DefiniteDescriptor` from which it is derived automatically. `DrainWeights` is now computed internally from `ChangeScript` — there is a single source of truth.

`ChangeScript::Descriptor` also accepts optional `satisfaction_assets` — when provided, the satisfaction weight is computed via `Plan` for a tighter estimate (useful for multisig/complex descriptors). Otherwise it falls back to `max_weight_to_satisfy`.

The raw `bdk_coin_select::ChangePolicy` is also replaced with a **`ChangePolicy` enum** (`NoDust`, `NoDustLeastWaste`) that is converted to the `bdk_coin_select` type internally. This is `Debug + Clone + PartialEq + Eq`.

Both `ChangeScript` and `ChangePolicy` have constructor methods to reduce boilerplate:
- `ChangeScript::from_descriptor(desc)`, `from_descriptor_with_assets(desc, assets)`, `from_script(script, weight)`
- `ChangePolicy::no_dust()`, `no_dust_least_waste(rate)`, with a builder-style `.min_value(amt)`

**2. Hacky `AbsoluteFee` implementation**

`FeeStrategy::AbsoluteFee` was implemented by smuggling the fee into `value_sum` and setting the feerate to zero. This meant the coin selector had no awareness of the fee, which interacted poorly with RBF logic (the zero feerate bypasses the original tx's feerate floor). Removed in favor of a direct `target_feerate: FeeRate` field.

### Design rationale

The satisfaction weight is a physical property of the script — it describes how much it costs to spend a particular output. It is not a policy choice. When `change_script` is a descriptor, the satisfaction weight is literally derived from it. The fact that it *affects* coin selection doesn't make it *part of* the change policy, any more than the dust threshold is (and dust is already derived from the script).

For the raw script case (e.g. silent payments), the satisfaction weight can't be derived and must be provided externally — but it's still a property of the script, not a policy decision. Bundling it into `ChangeScript::Script` makes this explicit.

## Context

* https://github.com/bitcoindevkit/bdk-tx/pull/18#issuecomment-3906226448
* https://github.com/bitcoindevkit/bdk-tx/pull/32#discussion_r2815577014