### PR TITLE
ci: update CI actions and enable caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,12 @@ jobs:
           - --no-default-features --features miniscript/no-std
           - --all-features
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            toolchain: ${{ matrix.rust.version }}
+          toolchain: ${{ matrix.rust.version }}
+          cache: true
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.85.0'
         run: ./ci/pin-msrv.sh
@@ -38,23 +39,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            toolchain: stable
+          toolchain: stable
+          cache: true
       - name: Check no-std
         run: cargo check --no-default-features --features miniscript/no-std
 
   fmt-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            toolchain: stable
-            components: clippy, rustfmt
+          toolchain: stable
+          components: clippy, rustfmt
+          cache: true
       - name: Rust fmt
         run: cargo fmt --all -- --check
       - name: Clippy


### PR DESCRIPTION
### Description
Update CI workflow to use actions-rust-lang/setup-rust-toolchain with caching and bump actions/checkout to v6