### PR TITLE
fix(deps): replace deprecated FeeRate::from_sat_per_vb_unchecked

### DIFF
--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
     let (tip_height, tip_time) = wallet.tip_info(env.rpc_client())?;
     println!("Current height: {}", tip_height);
-    let longterm_feerate = FeeRate::from_sat_per_vb_unchecked(1);
+    let longterm_feerate = FeeRate::from_sat_per_vb(1).expect("valid fee rate");
 
     let recipient_addr = env
         .rpc_client()
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
                     // For waste optimization when deciding change.
                     change_longterm_feerate: Some(longterm_feerate),
                     ..SelectorParams::new(
-                        FeeRate::from_sat_per_vb_unchecked(10),
+                        FeeRate::from_sat_per_vb(10).expect("valid fee rate"),
                         vec![Output::with_script(
                             recipient_addr.script_pubkey(),
                             Amount::from_sat(50_000_000),

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
     println!("Balance (pending): {}", wallet.balance());
 
     let (tip_height, tip_mtp) = wallet.tip_info(env.rpc_client())?;
-    let longterm_feerate = FeeRate::from_sat_per_vb_unchecked(1);
+    let longterm_feerate = FeeRate::from_sat_per_vb(1).expect("valid fee rate");
 
     let recipient_addr = env
         .rpc_client()
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
                 // For waste-optimization when deciding change.
                 change_longterm_feerate: Some(longterm_feerate),
                 ..SelectorParams::new(
-                    FeeRate::from_sat_per_vb_unchecked(10),
+                    FeeRate::from_sat_per_vb(10).expect("valid fee rate"),
                     vec![Output::with_script(
                         recipient_addr.script_pubkey(),
                         Amount::from_sat(21_000_000),
@@ -131,7 +131,7 @@ fn main() -> anyhow::Result<()> {
                 SelectorParams {
                     // This is just a lower-bound feerate. The actual result will be much higher to
                     // satisfy mempool-replacement policy.
-                    target_feerate: FeeRate::from_sat_per_vb_unchecked(1),
+                    target_feerate: FeeRate::from_sat_per_vb(1).expect("valid fee rate"),
                     // We cancel the tx by specifying no target outputs. This way, all excess returns
                     // to our change output (unless if the prevouts picked are so small that it will
                     // be less wasteful to have no output, however that will not be a valid tx).

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -213,7 +213,7 @@ impl RbfParams {
     {
         Self {
             original_txs: tx_to_replace.into_iter().map(Into::into).collect(),
-            incremental_relay_feerate: FeeRate::from_sat_per_vb_unchecked(1),
+            incremental_relay_feerate: FeeRate::from_sat_per_vb(1).expect("valid fee rate"),
         }
     }
 


### PR DESCRIPTION
### Description
- `FeeRate::from_sat_per_vb_unchecked` got deprecated in `bitcoin-units 0.1.3`, which broke CI
- I swapped it for `FeeRate::from_sat_per_vb(n)` everywhere
- I went with `from_sat_per_vb` instead of `from_sat_per_vb_u32` for compatibility. `from_sat_per_vb_u32` would require a direct bitcoin-units >= 0.1.3 constraint; bitcoin only requires bitcoin-units = "0.1.0", so it can still resolve to versions without that API