### PR TITLE
feat: introduce TxTemplate as an intermediate stage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 bdk_coin_select = { version = "0.4.1" }
 miniscript = { version = "12.3.7", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
-rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -27,6 +26,7 @@ bitcoin = { version = "0.32.10", default-features = false, features = ["rand-std
 bdk_testenv = "0.13.0"
 bdk_bitcoind_rpc = "0.22.0"
 bdk_chain = { version = "0.23.3" }
+rand = "0.8"
 
 [features]
 default = ["std"]

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
             .all_candidates()
             .regroup(group_by_spk())
             .filter(filter_unspendable(tip_height, Some(tip_time)))
-            .into_selection(
+            .into_tx_template(
                 selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
                 SelectorParams {
                     // For waste optimization when deciding change.

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtParams,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtBuildParams,
     SelectorParams,
 };
 use bitcoin::{absolute::LockTime, key::Secp256k1, Amount, FeeRate};
@@ -90,10 +90,9 @@ fn main() -> anyhow::Result<()> {
 
         let selection_inputs = selection.inputs().to_vec();
 
-        let psbt = selection.create_psbt(PsbtParams {
-            anti_fee_sniping: Some(tip_height),
-            ..Default::default()
-        })?;
+        let (psbt, _) = selection
+            .apply_anti_fee_sniping(tip_height, &mut rand::thread_rng())?
+            .create_psbt(PsbtBuildParams::default())?;
 
         let tx = psbt.unsigned_tx;
 

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtBuildParams,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, BuildPsbtParams, Output,
     SelectorParams,
 };
 use bitcoin::{absolute::LockTime, key::Secp256k1, Amount, FeeRate};
@@ -92,7 +92,7 @@ fn main() -> anyhow::Result<()> {
 
         let (psbt, _) = selection
             .apply_anti_fee_sniping(tip_height, &mut rand::thread_rng())?
-            .create_psbt(PsbtBuildParams::default())?;
+            .build_psbt(BuildPsbtParams::default())?;
 
         let tx = psbt.unsigned_tx;
 

--- a/examples/anti_fee_sniping.rs
+++ b/examples/anti_fee_sniping.rs
@@ -91,7 +91,7 @@ fn main() -> anyhow::Result<()> {
         let selection_inputs = selection.inputs().to_vec();
 
         let (psbt, _) = selection
-            .apply_anti_fee_sniping(tip_height, &mut rand::thread_rng())?
+            .discourage_fee_sniping(tip_height, &mut rand::thread_rng())?
             .build_psbt(BuildPsbtParams::default())?;
 
         let tx = psbt.unsigned_tx;

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
         .all_candidates()
         .regroup(group_by_spk())
         .filter(filter_unspendable(tip_height, Some(tip_mtp)))
-        .into_selection(
+        .into_tx_template(
             selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
             SelectorParams {
                 // For waste-optimization when deciding change.
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
 
         let selection = rbf_candidates
             // Do coin selection.
-            .into_selection(
+            .into_tx_template(
                 // Coin selection algorithm.
                 selection_algorithm_lowest_fee_bnb(longterm_feerate, 100_000),
                 SelectorParams {

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,6 +1,6 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtParams,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtBuildParams,
     SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate};
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
         .assume_checked();
 
     // Okay now create tx.
-    let selection = wallet
+    let (mut psbt, finalizer) = wallet
         .all_candidates()
         .regroup(group_by_spk())
         .filter(filter_unspendable(tip_height, Some(tip_mtp)))
@@ -66,10 +66,8 @@ fn main() -> anyhow::Result<()> {
                     bdk_tx::ChangeScript::from_descriptor(internal.at_derivation_index(0)?),
                 )
             },
-        )?;
-
-    let mut psbt = selection.create_psbt(PsbtParams::default())?;
-    let finalizer = selection.into_finalizer();
+        )?
+        .create_psbt(PsbtBuildParams::default())?;
 
     let _ = psbt.sign(&signer, &secp);
     let res = finalizer.finalize(&mut psbt);
@@ -146,7 +144,6 @@ fn main() -> anyhow::Result<()> {
                 },
             )?;
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
         println!(
             "selected inputs: {:?}",
             selection
@@ -156,7 +153,7 @@ fn main() -> anyhow::Result<()> {
                 .collect::<Vec<_>>()
         );
 
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
         psbt.sign(&signer, &secp).expect("failed to sign");
         assert!(
             finalizer.finalize(&mut psbt).is_finalized(),

--- a/examples/synopsis.rs
+++ b/examples/synopsis.rs
@@ -1,6 +1,6 @@
 use bdk_testenv::{bitcoincore_rpc::RpcApi, TestEnv};
 use bdk_tx::{
-    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, Output, PsbtBuildParams,
+    filter_unspendable, group_by_spk, selection_algorithm_lowest_fee_bnb, BuildPsbtParams, Output,
     SelectorParams, Signer,
 };
 use bitcoin::{key::Secp256k1, Amount, FeeRate};
@@ -67,7 +67,7 @@ fn main() -> anyhow::Result<()> {
                 )
             },
         )?
-        .create_psbt(PsbtBuildParams::default())?;
+        .build_psbt(BuildPsbtParams::default())?;
 
     let _ = psbt.sign(&signer, &secp);
     let res = finalizer.finalize(&mut psbt);
@@ -153,7 +153,7 @@ fn main() -> anyhow::Result<()> {
                 .collect::<Vec<_>>()
         );
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
         psbt.sign(&signer, &secp).expect("failed to sign");
         assert!(
             finalizer.finalize(&mut psbt).is_finalized(),

--- a/src/afs.rs
+++ b/src/afs.rs
@@ -117,7 +117,12 @@ pub(crate) fn apply_anti_fee_sniping(
         .collect();
 
     // Conditions that force nLockTime (vs nSequence).
-    let must_use_locktime = taproot_inputs.is_empty()
+    //
+    // The nSequence path exists so the tx resembles an off-chain settlement spending a timelock
+    // path, and those carry nLockTime = 0. So a locktime already pinned by an input's CLTV (or by
+    // `min_locktime`) rules the nSequence path out.
+    let must_use_locktime = tx.lock_time != LockTime::ZERO
+        || taproot_inputs.is_empty()
         || inputs.iter().any(|input| {
             let confirmation = input.confirmations(tip_height);
             confirmation == 0 || confirmation > MAX_RELATIVE_HEIGHT

--- a/src/afs.rs
+++ b/src/afs.rs
@@ -10,7 +10,7 @@ use miniscript::bitcoin::{
 };
 use rand_core::RngCore;
 
-/// Error returned by `apply_anti_fee_sniping`.
+/// Error returned by `discourage_fee_sniping`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AntiFeeSnipingError {
     /// Transaction `version` must be >= 2 for AFS to use relative locktimes.
@@ -77,7 +77,7 @@ impl std::error::Error for AntiFeeSnipingError {}
 ///
 /// # See Also
 /// [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki)
-pub(crate) fn apply_anti_fee_sniping(
+pub(crate) fn discourage_fee_sniping(
     mut template: TxTemplate,
     tip_height: absolute::Height,
     rng: &mut impl RngCore,

--- a/src/afs.rs
+++ b/src/afs.rs
@@ -16,8 +16,8 @@ pub enum AntiFeeSnipingError {
     /// Transaction `version` must be >= 2 for AFS to use relative locktimes.
     UnsupportedVersion(Version),
     /// AFS only supports height-based locktimes. The transaction's locktime is
-    /// time-based (MTP), which can originate from either `TxTemplateParams::min_locktime`
-    /// or an input's time-based CLTV requirement.
+    /// time-based (MTP), which can originate from either `TxTemplate::set_locktime` or an
+    /// input's time-based CLTV requirement.
     UnsupportedLockTime(absolute::LockTime),
 }
 
@@ -73,7 +73,7 @@ impl std::error::Error for AntiFeeSnipingError {}
 /// # Errors
 /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `tx.version < 2`.
 /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `tx.lock_time` is time-based
-///   (either from `TxTemplateParams::min_locktime` or an input's time-based CLTV).
+///   (either from `TxTemplate::set_locktime` or an input's time-based CLTV).
 ///
 /// # See Also
 /// [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki)

--- a/src/afs.rs
+++ b/src/afs.rs
@@ -1,12 +1,12 @@
 use crate::{
     no_std_rand::{random_probability, random_range},
-    Input,
+    TxTemplate,
 };
 use alloc::vec::Vec;
 use miniscript::bitcoin::{
     absolute::{self, LockTime},
     transaction::Version,
-    Sequence, Transaction,
+    Sequence,
 };
 use rand_core::RngCore;
 
@@ -16,7 +16,7 @@ pub enum AntiFeeSnipingError {
     /// Transaction `version` must be >= 2 for AFS to use relative locktimes.
     UnsupportedVersion(Version),
     /// AFS only supports height-based locktimes. The transaction's locktime is
-    /// time-based (MTP), which can originate from either `PsbtParams::min_locktime`
+    /// time-based (MTP), which can originate from either `TxTemplateParams::min_locktime`
     /// or an input's time-based CLTV requirement.
     UnsupportedLockTime(absolute::LockTime),
 }
@@ -73,46 +73,46 @@ impl std::error::Error for AntiFeeSnipingError {}
 /// # Errors
 /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `tx.version < 2`.
 /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `tx.lock_time` is time-based
-///   (either from `PsbtParams::min_locktime` or an input's time-based CLTV).
+///   (either from `TxTemplateParams::min_locktime` or an input's time-based CLTV).
 ///
 /// # See Also
 /// [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki)
 pub(crate) fn apply_anti_fee_sniping(
-    tx: &mut Transaction,
-    inputs: &[Input],
+    mut template: TxTemplate,
     tip_height: absolute::Height,
     rng: &mut impl RngCore,
-) -> Result<(), AntiFeeSnipingError> {
+) -> Result<TxTemplate, AntiFeeSnipingError> {
     const MAX_RELATIVE_HEIGHT: u32 = 65_535;
     const FIFTY_PERCENT_PROBABILITY_RANGE: u32 = 2;
     const MIN_SEQUENCE_VALUE: u32 = 1;
     const TEN_PERCENT_PROBABILITY_RANGE: u32 = 10;
     const MAX_RANDOM_OFFSET: u32 = 100;
 
-    if tx.version < Version::TWO {
-        return Err(AntiFeeSnipingError::UnsupportedVersion(tx.version));
+    if template.version() < Version::TWO {
+        return Err(AntiFeeSnipingError::UnsupportedVersion(template.version()));
     }
 
-    if !tx.lock_time.is_block_height() {
-        return Err(AntiFeeSnipingError::UnsupportedLockTime(tx.lock_time));
+    if !template.lock_time().is_block_height() {
+        return Err(AntiFeeSnipingError::UnsupportedLockTime(
+            template.lock_time(),
+        ));
     }
 
-    let rbf_enabled = tx.is_explicitly_rbf();
+    // A tx signals RBF if at least one input has `nSequence < 0xfffffffe`.
+    let fallback = template.fallback_sequence();
+    let rbf_enabled = template
+        .inputs()
+        .iter()
+        .any(|input| input.sequence().unwrap_or(fallback).is_rbf());
 
-    // vector of input_index and associated Input ref.
-    let taproot_inputs: Vec<(usize, &Input)> = tx
-        .input
+    // Indices of taproot inputs without a relative timelock — candidates for the nSequence path.
+    let taproot_inputs: Vec<usize> = template
+        .inputs()
         .iter()
         .enumerate()
-        .filter_map(|(vin, txin)| {
-            let input = inputs
-                .iter()
-                .find(|input| input.prev_outpoint() == txin.previous_output)?;
-            if input.prev_txout().script_pubkey.is_p2tr() && input.relative_timelock().is_none() {
-                Some((vin, input))
-            } else {
-                None
-            }
+        .filter_map(|(i, input)| {
+            (input.prev_txout().script_pubkey.is_p2tr() && input.relative_timelock().is_none())
+                .then_some(i)
         })
         .collect();
 
@@ -120,37 +120,36 @@ pub(crate) fn apply_anti_fee_sniping(
     //
     // The nSequence path exists so the tx resembles an off-chain settlement spending a timelock
     // path, and those carry nLockTime = 0. So a locktime already pinned by an input's CLTV (or by
-    // `min_locktime`) rules the nSequence path out.
-    let must_use_locktime = tx.lock_time != LockTime::ZERO
+    // `set_locktime`) rules the nSequence path out.
+    let must_use_locktime = template.lock_time() != LockTime::ZERO
         || taproot_inputs.is_empty()
-        || inputs.iter().any(|input| {
+        || template.inputs().iter().any(|input| {
             let confirmation = input.confirmations(tip_height);
             confirmation == 0 || confirmation > MAX_RELATIVE_HEIGHT
         });
     let use_locktime = !rbf_enabled
         || must_use_locktime
-        || taproot_inputs.is_empty()
         || random_probability(rng, FIFTY_PERCENT_PROBABILITY_RANGE);
 
     if use_locktime {
-        // Use nLockTime
         let mut afs_height = tip_height.to_consensus_u32();
-
         if random_probability(rng, TEN_PERCENT_PROBABILITY_RANGE) {
             let random_offset = random_range(rng, MAX_RANDOM_OFFSET);
             afs_height = afs_height.saturating_sub(random_offset);
         }
-
         let afs_locktime = LockTime::from_height(afs_height).expect("must be valid Height");
 
-        if tx.lock_time.is_implied_by(afs_locktime) {
-            tx.lock_time = afs_locktime;
+        // Only apply if it's a bump (i.e. doesn't regress an input's CLTV requirement).
+        if template.lock_time().is_implied_by(afs_locktime) {
+            template = template
+                .set_locktime(afs_locktime)
+                .expect("AFS picks a value ≥ current lock_time (same height-based unit)");
         }
     } else {
-        // Use Sequence
-        let random_index = random_range(rng, taproot_inputs.len() as u32);
-        let (input_index, input) = taproot_inputs[random_index as usize];
-        let confirmation = input.confirmations(tip_height);
+        let random_index = random_range(rng, taproot_inputs.len() as u32) as usize;
+        let input_index = taproot_inputs[random_index];
+        let outpoint = template.inputs()[input_index].prev_outpoint();
+        let confirmation = template.inputs()[input_index].confirmations(tip_height);
 
         let mut sequence_value = confirmation;
         if random_probability(rng, TEN_PERCENT_PROBABILITY_RANGE) {
@@ -160,8 +159,12 @@ pub(crate) fn apply_anti_fee_sniping(
                 .max(MIN_SEQUENCE_VALUE);
         }
 
-        tx.input[input_index].sequence = Sequence(sequence_value);
+        template
+            .input_mut(outpoint)
+            .expect("taproot input index resolved above")
+            .set_sequence(Sequence(sequence_value))
+            .expect("AFS only picks inputs without timelock constraints");
     }
 
-    Ok(())
+    Ok(template)
 }

--- a/src/build_psbt.rs
+++ b/src/build_psbt.rs
@@ -1,0 +1,75 @@
+//! Parameters and error type for [`TxTemplate::build_psbt`].
+//!
+//! The build logic itself lives as an inherent method on [`TxTemplate`]; only the standalone
+//! parameter and error types are housed here to keep `tx_template.rs` focused on tx shaping.
+//!
+//! [`TxTemplate::build_psbt`]: crate::TxTemplate::build_psbt
+
+use alloc::boxed::Box;
+use core::fmt::Display;
+
+use miniscript::bitcoin;
+
+use crate::Input;
+
+/// Parameters for emitting a [`Psbt`] from a [`TxTemplate`].
+///
+/// Carries only PSBT-specific options. Transaction-shape decisions (version, locktime,
+/// sequence, anti-fee-sniping, input/output ordering) all live on [`TxTemplate`].
+///
+/// [`Psbt`]: bitcoin::Psbt
+/// [`TxTemplate`]: crate::TxTemplate
+#[derive(Debug, Clone)]
+pub struct BuildPsbtParams {
+    /// Whether to require the full tx (aka [`non_witness_utxo`]) for segwit v0 inputs.
+    ///
+    /// Default: `true`.
+    ///
+    /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
+    pub mandate_full_tx_for_segwit_v0: bool,
+}
+
+impl Default for BuildPsbtParams {
+    fn default() -> Self {
+        Self {
+            mandate_full_tx_for_segwit_v0: true,
+        }
+    }
+}
+
+/// Error returned by [`TxTemplate::build_psbt`].
+///
+/// [`TxTemplate::build_psbt`]: crate::TxTemplate::build_psbt
+#[derive(Debug)]
+pub enum BuildPsbtError {
+    /// Missing tx for legacy input.
+    MissingFullTxForLegacyInput(Box<Input>),
+    /// Missing tx for segwit v0 input.
+    MissingFullTxForSegwitV0Input(Box<Input>),
+    /// Psbt error.
+    Psbt(bitcoin::psbt::Error),
+    /// Update psbt output with descriptor error.
+    OutputUpdate(miniscript::psbt::OutputUpdateError),
+}
+
+impl Display for BuildPsbtError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingFullTxForLegacyInput(input) => write!(
+                f,
+                "legacy input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
+                input.prev_outpoint()
+            ),
+            Self::MissingFullTxForSegwitV0Input(input) => write!(
+                f,
+                "segwit v0 input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
+                input.prev_outpoint()
+            ),
+            Self::Psbt(e) => Display::fmt(e, f),
+            Self::OutputUpdate(e) => Display::fmt(e, f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for BuildPsbtError {}

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -14,7 +14,7 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 ///
 /// # Usage
 ///
-/// A [`Finalizer`] is typically obtained alongside a PSBT from [`TxTemplate::create_psbt`].
+/// A [`Finalizer`] is typically obtained alongside a PSBT from [`TxTemplate::build_psbt`].
 /// It can also be constructed directly from a list of `(outpoint, plan)` pairs via
 /// [`Finalizer::new`]. Use [`finalize_input`] to finalize a single input, or [`finalize`] to
 /// finalize every input. Upon finalizing the PSBT, the [`Finalizer`] also clears metadata from
@@ -23,12 +23,12 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 /// # Example
 ///
 /// ```rust,no_run
-/// # use bdk_tx::PsbtBuildParams;
+/// # use bdk_tx::BuildPsbtParams;
 /// # let secp = bitcoin::secp256k1::Secp256k1::new();
 /// # let keymap = std::collections::BTreeMap::new();
 /// # let template: bdk_tx::TxTemplate = unimplemented!();
 /// // Create PSBT from a selection of inputs and outputs.
-/// let (mut psbt, finalizer) = template.create_psbt(PsbtBuildParams::default())?;
+/// let (mut psbt, finalizer) = template.build_psbt(BuildPsbtParams::default())?;
 ///
 /// // Sign the PSBT using your preferred method.
 /// let signer = bdk_tx::Signer(keymap);
@@ -45,7 +45,7 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 ///
 /// [BIP174]: <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#input-finalizer>
 /// [`TxTemplate`]: crate::TxTemplate
-/// [`TxTemplate::create_psbt`]: crate::TxTemplate::create_psbt
+/// [`TxTemplate::build_psbt`]: crate::TxTemplate::build_psbt
 /// [`Plan`]: miniscript::plan::Plan
 /// [`Transaction`]: bitcoin::Transaction
 /// [`finalize_input`]: Finalizer::finalize_input
@@ -163,7 +163,7 @@ impl FinalizeMap {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
-    use crate::{Finalizer, Output, PsbtBuildParams, Signer, TxTemplate};
+    use crate::{BuildPsbtParams, Finalizer, Output, Signer, TxTemplate};
     use bitcoin::secp256k1::Secp256k1;
     use bitcoin::{absolute, transaction, Amount, ScriptBuf, TxIn, TxOut};
     use miniscript::bitcoin;
@@ -217,7 +217,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);
@@ -236,7 +236,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);
@@ -264,7 +264,7 @@ mod tests {
             ],
         );
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
         assert!(!psbt.outputs[0].tap_key_origins.is_empty());
         assert!(psbt.outputs[0].tap_internal_key.is_some());
@@ -318,7 +318,7 @@ mod tests {
             ],
         );
 
-        let (mut psbt, _) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, _) = selection.build_psbt(BuildPsbtParams::default())?;
 
         let tap_key_origins = psbt.outputs[0].tap_key_origins.clone();
         let tap_internal_key = psbt.outputs[0].tap_internal_key;
@@ -358,7 +358,7 @@ mod tests {
             ],
         );
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
         let tap_key_origins = psbt.outputs[0].tap_key_origins.clone();
         let tap_internal_key = psbt.outputs[0].tap_internal_key;
@@ -385,7 +385,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
+        let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -15,7 +15,7 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 /// # Usage
 ///
 /// Construct a [`Finalizer`] from a list of `(outpoint, plan)` pairs, or by calling
-/// [`into_finalizer`] on a particular [`Selection`]. Use [`finalize_input`] to finalize a single
+/// [`into_finalizer`] on a particular [`TxTemplate`]. Use [`finalize_input`] to finalize a single
 /// input, or [`finalize`] to finalize every input and return a map containing the result of
 /// finalization at each index. Upon finalizing the PSBT, the [`Finalizer`] also clears metadata
 /// from non-essential fields of the PSBT inputs and outputs, ensuring that only the necessary
@@ -27,16 +27,16 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 /// # use bdk_tx::PsbtParams;
 /// # let secp = bitcoin::secp256k1::Secp256k1::new();
 /// # let keymap = std::collections::BTreeMap::new();
-/// # let selection: bdk_tx::Selection = unimplemented!();
+/// # let template: bdk_tx::TxTemplate = unimplemented!();
 /// // Create PSBT from a selection of inputs and outputs.
-/// let mut psbt = selection.create_psbt(PsbtParams::default())?;
+/// let mut psbt = template.create_psbt(PsbtParams::default())?;
 ///
 /// // Sign the PSBT using your preferred method.
 /// let signer = bdk_tx::Signer(keymap);
 /// let _ = psbt.sign(&signer, &secp);
 ///
 /// // Finalize the PSBT.
-/// let finalizer = selection.into_finalizer();
+/// let finalizer = template.into_finalizer();
 /// let finalize_map = finalizer.finalize(&mut psbt);
 /// assert!(finalize_map.is_finalized());
 ///
@@ -46,8 +46,8 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 /// ```
 ///
 /// [BIP174]: <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#input-finalizer>
-/// [`Selection`]: crate::Selection
-/// [`into_finalizer`]: crate::Selection::into_finalizer
+/// [`TxTemplate`]: crate::TxTemplate
+/// [`into_finalizer`]: crate::TxTemplate::into_finalizer
 /// [`Plan`]: miniscript::plan::Plan
 /// [`Transaction`]: bitcoin::Transaction
 /// [`finalize_input`]: Finalizer::finalize_input
@@ -165,7 +165,7 @@ impl FinalizeMap {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
-    use crate::{Finalizer, Output, PsbtParams, Selection, Signer};
+    use crate::{Finalizer, Output, PsbtParams, Signer, TxTemplate};
     use bitcoin::secp256k1::Secp256k1;
     use bitcoin::{absolute, transaction, Amount, ScriptBuf, TxIn, TxOut};
     use miniscript::bitcoin;
@@ -217,7 +217,7 @@ mod tests {
     fn test_finalize_single_input() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = Selection::new(vec![input], vec![output]);
+        let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
         let mut psbt = selection.create_psbt(PsbtParams::default())?;
         let finalizer = selection.into_finalizer();
@@ -237,7 +237,7 @@ mod tests {
     fn test_finalize_sets_final_script_sig() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(PKH_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = Selection::new(vec![input], vec![output]);
+        let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
         let mut psbt = selection.create_psbt(PsbtParams::default())?;
         let finalizer = selection.into_finalizer();
@@ -260,7 +260,7 @@ mod tests {
         let taproot_output_descriptor = derive_descriptor_at(TR_XPRV, 10)?;
         let wpkh_output_descriptor = derive_descriptor_at(WPKH_XPRV, 11)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input_0, input_1, input_2],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -315,7 +315,7 @@ mod tests {
             input_0.plan().cloned().expect("plan must exist"),
         )]);
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input_0, input_1],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -355,7 +355,7 @@ mod tests {
         let (input, _) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let taproot_output_descriptor = derive_descriptor_at(TR_XPRV, 10)?;
         let wpkh_output_descriptor = derive_descriptor_at(WPKH_XPRV, 11)?;
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -389,7 +389,7 @@ mod tests {
     fn test_already_finalized_input() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = Selection::new(vec![input], vec![output]);
+        let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
         let mut psbt = selection.create_psbt(PsbtParams::default())?;
         let finalizer = selection.into_finalizer();

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -14,29 +14,27 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 ///
 /// # Usage
 ///
-/// Construct a [`Finalizer`] from a list of `(outpoint, plan)` pairs, or by calling
-/// [`into_finalizer`] on a particular [`TxTemplate`]. Use [`finalize_input`] to finalize a single
-/// input, or [`finalize`] to finalize every input and return a map containing the result of
-/// finalization at each index. Upon finalizing the PSBT, the [`Finalizer`] also clears metadata
-/// from non-essential fields of the PSBT inputs and outputs, ensuring that only the necessary
-/// information remains for transaction extraction.
+/// A [`Finalizer`] is typically obtained alongside a PSBT from [`TxTemplate::create_psbt`].
+/// It can also be constructed directly from a list of `(outpoint, plan)` pairs via
+/// [`Finalizer::new`]. Use [`finalize_input`] to finalize a single input, or [`finalize`] to
+/// finalize every input. Upon finalizing the PSBT, the [`Finalizer`] also clears metadata from
+/// non-essential fields of the PSBT inputs and outputs.
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// # use bdk_tx::PsbtParams;
+/// # use bdk_tx::PsbtBuildParams;
 /// # let secp = bitcoin::secp256k1::Secp256k1::new();
 /// # let keymap = std::collections::BTreeMap::new();
 /// # let template: bdk_tx::TxTemplate = unimplemented!();
 /// // Create PSBT from a selection of inputs and outputs.
-/// let mut psbt = template.create_psbt(PsbtParams::default())?;
+/// let (mut psbt, finalizer) = template.create_psbt(PsbtBuildParams::default())?;
 ///
 /// // Sign the PSBT using your preferred method.
 /// let signer = bdk_tx::Signer(keymap);
 /// let _ = psbt.sign(&signer, &secp);
 ///
 /// // Finalize the PSBT.
-/// let finalizer = template.into_finalizer();
 /// let finalize_map = finalizer.finalize(&mut psbt);
 /// assert!(finalize_map.is_finalized());
 ///
@@ -47,7 +45,7 @@ use miniscript::{bitcoin, plan::Plan, psbt::PsbtInputSatisfier};
 ///
 /// [BIP174]: <https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#input-finalizer>
 /// [`TxTemplate`]: crate::TxTemplate
-/// [`into_finalizer`]: crate::TxTemplate::into_finalizer
+/// [`TxTemplate::create_psbt`]: crate::TxTemplate::create_psbt
 /// [`Plan`]: miniscript::plan::Plan
 /// [`Transaction`]: bitcoin::Transaction
 /// [`finalize_input`]: Finalizer::finalize_input
@@ -165,7 +163,7 @@ impl FinalizeMap {
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
-    use crate::{Finalizer, Output, PsbtParams, Signer, TxTemplate};
+    use crate::{Finalizer, Output, PsbtBuildParams, Signer, TxTemplate};
     use bitcoin::secp256k1::Secp256k1;
     use bitcoin::{absolute, transaction, Amount, ScriptBuf, TxIn, TxOut};
     use miniscript::bitcoin;
@@ -219,8 +217,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);
@@ -239,8 +236,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);
@@ -268,8 +264,7 @@ mod tests {
             ],
         );
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
 
         assert!(!psbt.outputs[0].tap_key_origins.is_empty());
         assert!(psbt.outputs[0].tap_internal_key.is_some());
@@ -323,7 +318,7 @@ mod tests {
             ],
         );
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
+        let (mut psbt, _) = selection.create_psbt(PsbtBuildParams::default())?;
 
         let tap_key_origins = psbt.outputs[0].tap_key_origins.clone();
         let tap_internal_key = psbt.outputs[0].tap_internal_key;
@@ -363,8 +358,7 @@ mod tests {
             ],
         );
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
 
         let tap_key_origins = psbt.outputs[0].tap_key_origins.clone();
         let tap_internal_key = psbt.outputs[0].tap_internal_key;
@@ -391,8 +385,7 @@ mod tests {
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        let mut psbt = selection.create_psbt(PsbtParams::default())?;
-        let finalizer = selection.into_finalizer();
+        let (mut psbt, finalizer) = selection.create_psbt(PsbtBuildParams::default())?;
 
         let secp = Secp256k1::new();
         let signer = Signer(keymap);

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -215,7 +215,7 @@ mod tests {
     fn test_finalize_single_input() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = TxTemplate::from_parts(vec![input], vec![output]);
+        let selection = TxTemplate::new(vec![input], vec![output]);
 
         let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
@@ -234,7 +234,7 @@ mod tests {
     fn test_finalize_sets_final_script_sig() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(PKH_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = TxTemplate::from_parts(vec![input], vec![output]);
+        let selection = TxTemplate::new(vec![input], vec![output]);
 
         let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 
@@ -256,7 +256,7 @@ mod tests {
         let taproot_output_descriptor = derive_descriptor_at(TR_XPRV, 10)?;
         let wpkh_output_descriptor = derive_descriptor_at(WPKH_XPRV, 11)?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input_0, input_1, input_2],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -310,7 +310,7 @@ mod tests {
             input_0.plan().cloned().expect("plan must exist"),
         )]);
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input_0, input_1],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -350,7 +350,7 @@ mod tests {
         let (input, _) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let taproot_output_descriptor = derive_descriptor_at(TR_XPRV, 10)?;
         let wpkh_output_descriptor = derive_descriptor_at(WPKH_XPRV, 11)?;
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![
                 Output::with_descriptor(taproot_output_descriptor, Amount::from_sat(20_000)),
@@ -383,7 +383,7 @@ mod tests {
     fn test_already_finalized_input() -> anyhow::Result<()> {
         let (input, keymap) = create_input_from_descriptor_at(TR_XPRV, 0)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = TxTemplate::from_parts(vec![input], vec![output]);
+        let selection = TxTemplate::new(vec![input], vec![output]);
 
         let (mut psbt, finalizer) = selection.build_psbt(BuildPsbtParams::default())?;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -665,16 +665,16 @@ impl Input {
     }
 }
 
-/// Mutable handle to an [`Input`] held inside a [`Selection`].
+/// Mutable handle to an [`Input`] held inside a [`TxTemplate`].
 ///
-/// Returned by [`Selection::input_mut`] and [`Selection::inputs_mut`]. This wrapper restricts
-/// mutation to operations that preserve [`Selection`]'s coin-selection invariants.
+/// Returned by [`TxTemplate::input_mut`] and [`TxTemplate::inputs_mut`]. This wrapper restricts
+/// mutation to operations that preserve [`TxTemplate`]'s coin-selection invariants.
 ///
 /// Read-only access to the underlying [`Input`] is available via [`Deref`].
 ///
-/// [`Selection`]: crate::Selection
-/// [`Selection::input_mut`]: crate::Selection::input_mut
-/// [`Selection::inputs_mut`]: crate::Selection::inputs_mut
+/// [`TxTemplate`]: crate::TxTemplate
+/// [`TxTemplate::input_mut`]: crate::TxTemplate::input_mut
+/// [`TxTemplate::inputs_mut`]: crate::TxTemplate::inputs_mut
 /// [`Deref`]: core::ops::Deref
 #[derive(Debug)]
 pub struct InputMut<'a>(&'a mut Input);

--- a/src/input.rs
+++ b/src/input.rs
@@ -668,7 +668,7 @@ impl Input {
 /// Mutable handle to an [`Input`] held inside a [`TxTemplate`].
 ///
 /// Returned by [`TxTemplate::input_mut`] and [`TxTemplate::inputs_mut`]. This wrapper restricts
-/// mutation to operations that preserve [`TxTemplate`]'s coin-selection invariants.
+/// mutation to operations that preserve the template's invariants.
 ///
 /// Read-only access to the underlying [`Input`] is available via [`Deref`].
 ///

--- a/src/input_candidates.rs
+++ b/src/input_candidates.rs
@@ -7,8 +7,8 @@ use miniscript::bitcoin;
 
 use crate::collections::{BTreeMap, HashSet};
 use crate::{
-    CannotMeetTarget, FeeRateExt, Input, InputGroup, Selection, Selector, SelectorError,
-    SelectorParams,
+    CannotMeetTarget, FeeRateExt, Input, InputGroup, Selector, SelectorError, SelectorParams,
+    TxTemplate,
 };
 
 /// Input candidates.
@@ -191,30 +191,30 @@ impl InputCandidates {
         self
     }
 
-    /// Attempt to convert the input candidates into a valid [`Selection`] with a given
+    /// Attempt to convert the input candidates into a valid [`TxTemplate`] with a given
     /// `algorithm` and selector `params`.
-    pub fn into_selection<A, E>(
+    pub fn into_tx_template<A, E>(
         self,
         algorithm: A,
         params: SelectorParams,
-    ) -> Result<Selection, IntoSelectionError<E>>
+    ) -> Result<TxTemplate, IntoTxTemplateError<E>>
     where
         A: FnMut(&mut Selector) -> Result<(), E>,
     {
-        let mut selector = Selector::new(&self, params).map_err(IntoSelectionError::Selector)?;
+        let mut selector = Selector::new(&self, params).map_err(IntoTxTemplateError::Selector)?;
         selector
             .select_with_algorithm(algorithm)
-            .map_err(IntoSelectionError::SelectionAlgorithm)?;
+            .map_err(IntoTxTemplateError::SelectionAlgorithm)?;
         let selection = selector
             .try_finalize()
-            .ok_or(IntoSelectionError::CannotMeetTarget(CannotMeetTarget))?;
+            .ok_or(IntoTxTemplateError::CannotMeetTarget(CannotMeetTarget))?;
         Ok(selection)
     }
 }
 
 /// Occurs when we cannot find a solution for selection.
 #[derive(Debug)]
-pub enum IntoSelectionError<E> {
+pub enum IntoTxTemplateError<E> {
     /// Coin selector returned an error
     Selector(SelectorError),
     /// Selection algorithm failed.
@@ -223,22 +223,22 @@ pub enum IntoSelectionError<E> {
     CannotMeetTarget(CannotMeetTarget),
 }
 
-impl<E: fmt::Display> fmt::Display for IntoSelectionError<E> {
+impl<E: fmt::Display> fmt::Display for IntoTxTemplateError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            IntoSelectionError::Selector(error) => {
+            IntoTxTemplateError::Selector(error) => {
                 write!(f, "{error}")
             }
-            IntoSelectionError::SelectionAlgorithm(error) => {
+            IntoTxTemplateError::SelectionAlgorithm(error) => {
                 write!(f, "selection algorithm failed: {error}")
             }
-            IntoSelectionError::CannotMeetTarget(error) => write!(f, "{error}"),
+            IntoTxTemplateError::CannotMeetTarget(error) => write!(f, "{error}"),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: fmt::Debug + fmt::Display> std::error::Error for IntoSelectionError<E> {}
+impl<E: fmt::Debug + fmt::Display> std::error::Error for IntoTxTemplateError<E> {}
 
 /// Select for lowest fee with bnb
 pub fn selection_algorithm_lowest_fee_bnb(

--- a/src/input_candidates.rs
+++ b/src/input_candidates.rs
@@ -191,8 +191,7 @@ impl InputCandidates {
         self
     }
 
-    /// Attempt to convert the input candidates into a valid [`TxTemplate`] with a given
-    /// `algorithm` and selector `params`.
+    /// Run coin selection with `algorithm` and selector `params`, returning a [`TxTemplate`].
     pub fn into_tx_template<A, E>(
         self,
         algorithm: A,
@@ -205,10 +204,9 @@ impl InputCandidates {
         selector
             .select_with_algorithm(algorithm)
             .map_err(IntoTxTemplateError::SelectionAlgorithm)?;
-        let selection = selector
+        selector
             .try_finalize()
-            .ok_or(IntoTxTemplateError::CannotMeetTarget(CannotMeetTarget))?;
-        Ok(selection)
+            .ok_or(IntoTxTemplateError::CannotMeetTarget(CannotMeetTarget))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate std;
 pub extern crate bdk_coin_select;
 
 mod afs;
+mod build_psbt;
 mod canonical_unspents;
 mod finalizer;
 mod input;
@@ -24,6 +25,7 @@ mod signer;
 mod tx_template;
 
 pub use afs::*;
+pub use build_psbt::*;
 pub use canonical_unspents::*;
 pub use finalizer::*;
 pub use input::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ mod input_candidates;
 mod no_std_rand;
 mod output;
 mod rbf;
-mod selection;
 mod selector;
 mod signer;
+mod tx_template;
 
 pub use afs::*;
 pub use canonical_unspents::*;
@@ -34,9 +34,9 @@ use miniscript::{DefiniteDescriptorKey, Descriptor};
 use no_std_rand::*;
 pub use output::*;
 pub use rbf::*;
-pub use selection::*;
 pub use selector::*;
 pub use signer::*;
+pub use tx_template::*;
 
 #[cfg(feature = "std")]
 pub(crate) mod collections {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -646,6 +646,52 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: pre-fix, the AFS nSequence path could fire on a tx whose `lock_time` was
+    /// already non-zero, producing a tx carrying *both* a near-tip locktime and a
+    /// confirmation-depth sequence — a fingerprint matching neither an ordinary wallet spend nor
+    /// an off-chain settlement, which is what the nSequence path exists to imitate.
+    #[test]
+    fn test_anti_fee_sniping_sequence_path_requires_zero_locktime() -> anyhow::Result<()> {
+        let tip = absolute::Height::from_consensus(3_000)?;
+        // Below the AFS target, so it does not otherwise interfere with the locktime path.
+        let min_locktime = absolute::LockTime::from_consensus(2_000);
+
+        // A confirmed Taproot input with no CSV: without `min_locktime` this would make the
+        // nSequence path reachable, so the test also guards against the fix being a no-op.
+        let input = setup_test_input(2_500)?;
+
+        let selection = Selection::new(
+            vec![input],
+            vec![Output::with_script(
+                ScriptBuf::new(),
+                Amount::from_sat(9_000),
+            )],
+        );
+
+        for _ in 0..100 {
+            let psbt = selection.create_psbt(PsbtParams {
+                min_locktime,
+                anti_fee_sniping: Some(tip),
+                ..Default::default()
+            })?;
+            let tx = psbt.unsigned_tx;
+
+            assert_eq!(
+                tx.input[0].sequence,
+                Sequence::ENABLE_RBF_NO_LOCKTIME,
+                "AFS must not take the nSequence path when tx.lock_time is non-zero",
+            );
+            assert!(
+                (tip.to_consensus_u32() - 100..=tip.to_consensus_u32())
+                    .contains(&tx.lock_time.to_consensus_u32()),
+                "AFS must still set a near-tip locktime, got {}",
+                tx.lock_time,
+            );
+        }
+
+        Ok(())
+    }
+
     /// Regression: pre-fix, the AFS nSequence path could pick a Taproot input that already carried
     /// a CSV (relative-timelock) requirement and overwrite its sequence. The presence of a regular
     /// Taproot input ensures the sequence path remains reachable — so the test also catches a

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -4,7 +4,7 @@ use miniscript::bitcoin;
 
 use crate::{
     DefiniteDescriptor, FeeRateExt, Input, InputCandidates, InputGroup, Output, ScriptSource,
-    Selection,
+    TxTemplate,
 };
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -486,7 +486,7 @@ impl<'c> Selector<'c> {
     /// Try get final selection.
     ///
     /// Return `None` if target is not met yet.
-    pub fn try_finalize(&self) -> Option<Selection> {
+    pub fn try_finalize(&self) -> Option<TxTemplate> {
         if !self.inner.is_target_met(self.target) {
             return None;
         }
@@ -506,7 +506,7 @@ impl<'c> Selector<'c> {
                 Amount::from_sat(maybe_change.value),
             )));
         }
-        Some(Selection::new(inputs, outputs))
+        Some(TxTemplate::from_parts(inputs, outputs))
     }
 }
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -483,9 +483,9 @@ impl<'c> Selector<'c> {
         Some(has_drain)
     }
 
-    /// Try get final selection.
+    /// Try to finalize the selection into a [`TxTemplate`].
     ///
-    /// Return `None` if target is not met yet.
+    /// Returns `None` if the target is not yet met.
     pub fn try_finalize(&self) -> Option<TxTemplate> {
         if !self.inner.is_target_met(self.target) {
             return None;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -404,7 +404,7 @@ impl<'c> Selector<'c> {
         }
 
         // Verify that all inputs agree on absolute timelock unit (height vs time).
-        // Downstream stages (build_psbt, apply_anti_fee_sniping) rely on this invariant.
+        // Downstream stages (build_psbt, discourage_fee_sniping) rely on this invariant.
         let mut unit: Option<bitcoin::absolute::LockTime> = None;
         for lt in candidates.inputs().filter_map(Input::absolute_timelock) {
             match unit {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -404,7 +404,7 @@ impl<'c> Selector<'c> {
         }
 
         // Verify that all inputs agree on absolute timelock unit (height vs time).
-        // Downstream stages (create_psbt, apply_anti_fee_sniping) rely on this invariant.
+        // Downstream stages (build_psbt, apply_anti_fee_sniping) rely on this invariant.
         let mut unit: Option<bitcoin::absolute::LockTime> = None;
         for lt in candidates.inputs().filter_map(Input::absolute_timelock) {
             match unit {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -506,7 +506,7 @@ impl<'c> Selector<'c> {
                 Amount::from_sat(maybe_change.value),
             )));
         }
-        Some(TxTemplate::from_parts(inputs, outputs))
+        Some(TxTemplate::new(inputs, outputs))
     }
 }
 

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -20,8 +20,8 @@ use miniscript::psbt::PsbtExt;
 use rand_core::RngCore;
 
 use crate::{
-    apply_anti_fee_sniping, fisher_yates_shuffle, AntiFeeSnipingError, Finalizer, Input, InputMut,
-    Output,
+    apply_anti_fee_sniping, fisher_yates_shuffle, AntiFeeSnipingError, BuildPsbtError,
+    BuildPsbtParams, Finalizer, Input, InputMut, Output,
 };
 
 /// Default `nSequence` for plan-based inputs that don't specify their own.
@@ -117,63 +117,6 @@ pub struct TxTemplate {
     outputs: Vec<Output>,
 }
 
-/// Parameters for emitting a [`Psbt`] from a [`TxTemplate`].
-///
-/// Carries only PSBT-specific options. Transaction-shape decisions (version, locktime,
-/// sequence, anti-fee-sniping, input/output ordering) all live on [`TxTemplate`].
-#[derive(Debug, Clone)]
-pub struct PsbtBuildParams {
-    /// Whether to require the full tx (aka [`non_witness_utxo`]) for segwit v0 inputs.
-    ///
-    /// Default: `true`.
-    ///
-    /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
-    pub mandate_full_tx_for_segwit_v0: bool,
-}
-
-impl Default for PsbtBuildParams {
-    fn default() -> Self {
-        Self {
-            mandate_full_tx_for_segwit_v0: true,
-        }
-    }
-}
-
-/// Error returned by [`TxTemplate::create_psbt`].
-#[derive(Debug)]
-pub enum BuildPsbtError {
-    /// Missing tx for legacy input.
-    MissingFullTxForLegacyInput(Box<Input>),
-    /// Missing tx for segwit v0 input.
-    MissingFullTxForSegwitV0Input(Box<Input>),
-    /// Psbt error.
-    Psbt(bitcoin::psbt::Error),
-    /// Update psbt output with descriptor error.
-    OutputUpdate(miniscript::psbt::OutputUpdateError),
-}
-
-impl Display for BuildPsbtError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::MissingFullTxForLegacyInput(input) => write!(
-                f,
-                "legacy input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
-                input.prev_outpoint()
-            ),
-            Self::MissingFullTxForSegwitV0Input(input) => write!(
-                f,
-                "segwit v0 input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
-                input.prev_outpoint()
-            ),
-            Self::Psbt(e) => Display::fmt(e, f),
-            Self::OutputUpdate(e) => Display::fmt(e, f),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for BuildPsbtError {}
-
 impl TxTemplate {
     pub(crate) fn from_parts(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
         let lock_time = max_input_cltv(&inputs).unwrap_or(absolute::LockTime::ZERO);
@@ -218,7 +161,7 @@ impl TxTemplate {
     /// Set the fallback `nSequence` used for inputs that don't specify their own.
     ///
     /// The fallback is applied lazily at materialization (in [`Self::to_unsigned_tx`] and
-    /// [`Self::create_psbt`]); calling this method after other transformations does not
+    /// [`Self::build_psbt`]); calling this method after other transformations does not
     /// retroactively change inputs whose sequence has already been set explicitly (e.g. by
     /// [`apply_anti_fee_sniping`](Self::apply_anti_fee_sniping)).
     pub fn set_fallback_sequence(mut self, sequence: Sequence) -> Self {
@@ -385,7 +328,7 @@ impl TxTemplate {
     }
 
     /// Build the [`Psbt`] and its associated [`Finalizer`].
-    pub fn create_psbt(self, params: PsbtBuildParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
+    pub fn build_psbt(self, params: BuildPsbtParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
         let tx = self.to_unsigned_tx();
         let mut psbt = Psbt::from_unsigned_tx(tx).map_err(BuildPsbtError::Psbt)?;
 
@@ -636,7 +579,7 @@ mod tests {
 
         let (psbt, _) = selection
             .set_locktime(absolute::LockTime::from_consensus(current_height))?
-            .create_psbt(PsbtBuildParams::default())?;
+            .build_psbt(BuildPsbtParams::default())?;
         assert_eq!(
             psbt.unsigned_tx.lock_time.to_consensus_u32(),
             current_height
@@ -660,7 +603,7 @@ mod tests {
 
             let (psbt, _) = selection
                 .apply_anti_fee_sniping(tip, &mut thread_rng())?
-                .create_psbt(PsbtBuildParams::default())?;
+                .build_psbt(BuildPsbtParams::default())?;
 
             let tx = psbt.unsigned_tx;
 
@@ -706,7 +649,7 @@ mod tests {
             let (psbt, _) = selection
                 .apply_anti_fee_sniping(tip, &mut thread_rng())
                 .unwrap()
-                .create_psbt(PsbtBuildParams::default())
+                .build_psbt(BuildPsbtParams::default())
                 .unwrap();
 
             let tx = psbt.unsigned_tx;
@@ -750,7 +693,7 @@ mod tests {
             let (psbt, _) = selection
                 .clone()
                 .apply_anti_fee_sniping(tip, &mut thread_rng())?
-                .create_psbt(PsbtBuildParams::default())?;
+                .build_psbt(BuildPsbtParams::default())?;
             assert_eq!(
                 psbt.unsigned_tx.lock_time, cltv,
                 "AFS must not overwrite an input's CLTV with a lower value",
@@ -787,7 +730,7 @@ mod tests {
                 .clone()
                 .set_locktime(lock_time)?
                 .apply_anti_fee_sniping(tip, &mut thread_rng())?
-                .create_psbt(PsbtBuildParams::default())?;
+                .build_psbt(BuildPsbtParams::default())?;
             let tx = psbt.unsigned_tx;
 
             assert_eq!(
@@ -854,7 +797,7 @@ mod tests {
             );
             let (psbt, _) = selection
                 .apply_anti_fee_sniping(tip, &mut thread_rng())?
-                .create_psbt(PsbtBuildParams::default())?;
+                .build_psbt(BuildPsbtParams::default())?;
             let tx = psbt.unsigned_tx;
 
             let csv_txin = tx

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -20,7 +20,7 @@ use miniscript::psbt::PsbtExt;
 use rand_core::RngCore;
 
 use crate::{
-    apply_anti_fee_sniping, fisher_yates_shuffle, AntiFeeSnipingError, BuildPsbtError,
+    discourage_fee_sniping, fisher_yates_shuffle, AntiFeeSnipingError, BuildPsbtError,
     BuildPsbtParams, Finalizer, Input, InputMut, Output,
 };
 
@@ -163,7 +163,7 @@ impl TxTemplate {
     /// The fallback is applied lazily at materialization (in [`Self::to_unsigned_tx`] and
     /// [`Self::build_psbt`]); calling this method after other transformations does not
     /// retroactively change inputs whose sequence has already been set explicitly (e.g. by
-    /// [`apply_anti_fee_sniping`](Self::apply_anti_fee_sniping)).
+    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping)).
     pub fn set_fallback_sequence(mut self, sequence: Sequence) -> Self {
         self.fallback_sequence = sequence;
         self
@@ -319,12 +319,12 @@ impl TxTemplate {
     ///
     /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `version < 2`.
     /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `lock_time` is time-based.
-    pub fn apply_anti_fee_sniping<R: RngCore>(
+    pub fn discourage_fee_sniping<R: RngCore>(
         self,
         tip_height: absolute::Height,
         rng: &mut R,
     ) -> Result<Self, AntiFeeSnipingError> {
-        apply_anti_fee_sniping(self, tip_height, rng)
+        discourage_fee_sniping(self, tip_height, rng)
     }
 
     /// Build the [`Psbt`] and its associated [`Finalizer`].
@@ -602,7 +602,7 @@ mod tests {
             let selection = TxTemplate::new(vec![input.clone()], vec![output]);
 
             let (psbt, _) = selection
-                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .discourage_fee_sniping(tip, &mut thread_rng())?
                 .build_psbt(BuildPsbtParams::default())?;
 
             let tx = psbt.unsigned_tx;
@@ -647,7 +647,7 @@ mod tests {
                 vec![output.clone()],
             );
             let (psbt, _) = selection
-                .apply_anti_fee_sniping(tip, &mut thread_rng())
+                .discourage_fee_sniping(tip, &mut thread_rng())
                 .unwrap()
                 .build_psbt(BuildPsbtParams::default())
                 .unwrap();
@@ -692,7 +692,7 @@ mod tests {
         for _ in 0..100 {
             let (psbt, _) = selection
                 .clone()
-                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .discourage_fee_sniping(tip, &mut thread_rng())?
                 .build_psbt(BuildPsbtParams::default())?;
             assert_eq!(
                 psbt.unsigned_tx.lock_time, cltv,
@@ -729,7 +729,7 @@ mod tests {
             let (psbt, _) = selection
                 .clone()
                 .set_locktime(lock_time)?
-                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .discourage_fee_sniping(tip, &mut thread_rng())?
                 .build_psbt(BuildPsbtParams::default())?;
             let tx = psbt.unsigned_tx;
 
@@ -796,7 +796,7 @@ mod tests {
                 vec![output.clone()],
             );
             let (psbt, _) = selection
-                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .discourage_fee_sniping(tip, &mut thread_rng())?
                 .build_psbt(BuildPsbtParams::default())?;
             let tx = psbt.unsigned_tx;
 
@@ -843,7 +843,7 @@ mod tests {
             )],
         );
 
-        let result = selection.apply_anti_fee_sniping(tip, &mut thread_rng());
+        let result = selection.discourage_fee_sniping(tip, &mut thread_rng());
 
         assert!(matches!(
             result,
@@ -869,7 +869,7 @@ mod tests {
 
         let result = selection
             .set_version(Version::ONE)?
-            .apply_anti_fee_sniping(current_height, &mut OsRng);
+            .discourage_fee_sniping(current_height, &mut OsRng);
 
         assert!(matches!(
             result,

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -178,6 +178,17 @@ impl TxTemplate {
     /// is *not* rejected, but per BIP-65 / Bitcoin's `IsFinalTx` rule the lock_time will
     /// then be ignored at validation time.
     ///
+    /// The value acts as a *floor*: `tx.lock_time` only ever moves up from here. A subsequent
+    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping) may raise it toward the chain
+    /// tip, but never lowers it. Note the converse of that: if you set a value within ~100
+    /// blocks of the tip, AFS's random backoff has no room below it and is effectively
+    /// truncated.
+    ///
+    /// Call this *before* [`discourage_fee_sniping`](Self::discourage_fee_sniping), not after.
+    /// AFS may protect the transaction by setting an input's `nSequence` instead of the
+    /// locktime, which it only does while `tx.lock_time` is zero; giving the locktime a value
+    /// afterwards produces a transaction carrying both, which is a distinctive fingerprint.
+    ///
     /// # Errors
     ///
     /// - [`SetLockTimeError::BelowInputCltv`] if `lock_time < required` (same unit).
@@ -307,18 +318,22 @@ impl TxTemplate {
     /// `tx.lock_time` (via [`set_locktime`](Self::set_locktime)) or the `nSequence` of one
     /// Taproot input (via [`Input::set_sequence`]).
     ///
-    /// AFS only operates on a height-based `tx.lock_time`. If any input's CLTV is time-based,
-    /// this returns [`AntiFeeSnipingError::UnsupportedLockTime`].
+    /// `tx.lock_time` only ever moves up: AFS raises it toward `tip_height` but never lowers a
+    /// value already in place, whether that came from an input's CLTV or from
+    /// [`set_locktime`](Self::set_locktime). So if `tx.lock_time` is already a block height
+    /// greater than the AFS target, this leaves it unchanged — the existing value by itself
+    /// prevents inclusion before `tip_height + 1`.
     ///
-    /// If `tx.lock_time` is already a block height greater than `tip_height` (e.g., because an
-    /// input's CLTV pins the tx to a future block), this leaves the template unchanged.
+    /// AFS only operates on a height-based `tx.lock_time`. If the locktime in effect is
+    /// time-based, this returns [`AntiFeeSnipingError::UnsupportedLockTime`].
     ///
     /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki).
     ///
     /// # Errors
     ///
     /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `version < 2`.
-    /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `lock_time` is time-based.
+    /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `tx.lock_time` is time-based, from
+    ///   either an input's CLTV or [`set_locktime`](Self::set_locktime).
     pub fn discourage_fee_sniping<R: RngCore>(
         self,
         tip_height: absolute::Height,
@@ -743,6 +758,33 @@ mod tests {
                     .contains(&tx.lock_time.to_consensus_u32()),
                 "AFS must still set a near-tip locktime, got {}",
                 tx.lock_time,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// `set_locktime` and `discourage_fee_sniping` write the same slot and compose monotonically:
+    /// the value set acts as a floor that AFS may raise toward the tip, never lower.
+    #[test]
+    fn test_anti_fee_sniping_never_lowers_caller_locktime() -> anyhow::Result<()> {
+        let current_height = 2_500;
+        let tip = absolute::Height::from_consensus(current_height)?;
+        let input = setup_test_input(2_000)?;
+
+        // Above the AFS target, so AFS must leave it alone.
+        let caller_locktime = absolute::LockTime::from_height(current_height + 10_000)?;
+
+        for _ in 0..100 {
+            let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
+            let tx = TxTemplate::new(vec![input.clone()], vec![output])
+                .set_locktime(caller_locktime)?
+                .discourage_fee_sniping(tip, &mut thread_rng())?
+                .to_unsigned_tx();
+
+            assert_eq!(
+                tx.lock_time, caller_locktime,
+                "AFS must not lower a lock_time that already exceeds its target",
             );
         }
 

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -118,7 +118,7 @@ pub struct TxTemplate {
 }
 
 impl TxTemplate {
-    pub(crate) fn from_parts(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
+    pub(crate) fn new(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
         let lock_time = max_input_cltv(&inputs).unwrap_or(absolute::LockTime::ZERO);
         Self {
             version: transaction::Version::TWO,
@@ -481,7 +481,7 @@ mod tests {
     fn set_locktime_height_above_input_cltv() -> anyhow::Result<()> {
         let cltv = absolute::LockTime::from_consensus(100_000);
         let (input, desc) = setup_cltv_input(cltv)?;
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -508,7 +508,7 @@ mod tests {
     fn set_locktime_below_input_cltv_errors() -> anyhow::Result<()> {
         let cltv = absolute::LockTime::from_consensus(100_000);
         let (input, desc) = setup_cltv_input(cltv)?;
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -532,7 +532,7 @@ mod tests {
     fn lock_time_takes_time_based_cltv_from_input() -> anyhow::Result<()> {
         let time_locktime = absolute::LockTime::from_consensus(1_734_230_218);
         let (input, desc) = setup_cltv_input(time_locktime)?;
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -550,7 +550,7 @@ mod tests {
     fn set_locktime_unit_mismatch_errors() -> anyhow::Result<()> {
         let height_cltv = absolute::LockTime::from_consensus(100_000);
         let (input, desc) = setup_cltv_input(height_cltv)?;
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -575,7 +575,7 @@ mod tests {
         let current_height = 2_500;
         let input = setup_test_input(2_000)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = TxTemplate::from_parts(vec![input], vec![output]);
+        let selection = TxTemplate::new(vec![input], vec![output]);
 
         let (psbt, _) = selection
             .set_locktime(absolute::LockTime::from_consensus(current_height))?
@@ -599,7 +599,7 @@ mod tests {
 
         while !used_locktime || !used_sequence {
             let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-            let selection = TxTemplate::from_parts(vec![input.clone()], vec![output]);
+            let selection = TxTemplate::new(vec![input.clone()], vec![output]);
 
             let (psbt, _) = selection
                 .apply_anti_fee_sniping(tip, &mut thread_rng())?
@@ -642,7 +642,7 @@ mod tests {
         let mut loops = 0;
 
         while !used_locktime || !used_sequence {
-            let selection = TxTemplate::from_parts(
+            let selection = TxTemplate::new(
                 vec![input1.clone(), input2.clone(), input3.clone()],
                 vec![output.clone()],
             );
@@ -681,7 +681,7 @@ mod tests {
         let (input, desc) = setup_cltv_input(cltv)?;
         let tip = absolute::Height::from_consensus(50_000)?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -717,7 +717,7 @@ mod tests {
         // nSequence path reachable, so the test also guards against the fix being a no-op.
         let input = setup_test_input(2_500)?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_script(
                 ScriptBuf::new(),
@@ -791,7 +791,7 @@ mod tests {
         let mut observed_sequence_path = false;
 
         for _ in 0..100 {
-            let selection = TxTemplate::from_parts(
+            let selection = TxTemplate::new(
                 vec![regular_input.clone(), csv_input.clone()],
                 vec![output.clone()],
             );
@@ -835,7 +835,7 @@ mod tests {
         let (input, desc) = setup_cltv_input(time_locktime)?;
         let tip = absolute::Height::from_consensus(800_000)?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -859,7 +859,7 @@ mod tests {
         let input = setup_test_input(confirmation_height)?;
         let current_height = absolute::Height::from_consensus(confirmation_height + 50)?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![input],
             vec![Output::with_script(
                 ScriptBuf::new(),
@@ -908,7 +908,7 @@ mod tests {
         };
         let csv_input = Input::from_prev_tx(plan, prev_tx, 0, Some(status))?;
 
-        let selection = TxTemplate::from_parts(
+        let selection = TxTemplate::new(
             vec![csv_input],
             vec![Output::with_script(
                 ScriptBuf::new(),

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -1,10 +1,21 @@
+//! Tx-shaping stage between coin selection and the final [`Psbt`] or [`Transaction`].
+//!
+//! A [`TxTemplate`] is obtained from [`Selector::try_finalize`] or
+//! [`InputCandidates::into_tx_template`], then mutated (sort, shuffle, anti-fee-sniping,
+//! set_version, set_locktime, set_fallback_sequence, per-input sequence overrides) before
+//! being emitted as a PSBT or a [`Transaction`].
+//!
+//! [`Selector::try_finalize`]: crate::Selector::try_finalize
+//! [`InputCandidates::into_tx_template`]: crate::InputCandidates::into_tx_template
+//! [`Transaction`]: bitcoin::Transaction
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
-use core::fmt::{Debug, Display};
+use core::fmt::Display;
 
 use miniscript::bitcoin;
-use miniscript::bitcoin::{absolute, transaction, OutPoint, Psbt, Sequence};
+use miniscript::bitcoin::{absolute, transaction, OutPoint, Psbt, Sequence, Transaction, TxIn};
 use miniscript::psbt::PsbtExt;
 use rand_core::RngCore;
 
@@ -13,80 +24,124 @@ use crate::{
     Output,
 };
 
-/// Final selection of inputs and outputs.
-#[derive(Debug, Clone)]
-#[must_use]
-pub struct TxTemplate {
-    inputs: Vec<Input>,
-    outputs: Vec<Output>,
+/// Default `nSequence` for plan-based inputs that don't specify their own.
+///
+/// Matches Bitcoin Core's wallet default (`0xfffffffd`,
+/// [`Sequence::ENABLE_RBF_NO_LOCKTIME`]).
+pub const FALLBACK_SEQUENCE: Sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+
+/// Error returned by [`TxTemplate::set_version`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum SetVersionError {
+    /// A relative-timelock input requires `version >= 2` (BIP-68).
+    RelativeTimelockRequiresV2 {
+        /// The version the caller attempted to set.
+        attempted: transaction::Version,
+    },
 }
 
-/// Parameters for creating a psbt.
-#[derive(Debug, Clone)]
-pub struct PsbtParams {
-    /// Use a specific [`transaction::Version`].
-    pub version: transaction::Version,
-
-    /// Minimum tx locktime — a floor on the resulting `tx.lock_time`.
-    ///
-    /// The final `tx.lock_time` is the maximum of this value and any absolute locktime required by
-    /// an input's CLTV, provided the locktime units agree. If `min_locktime` uses a different unit
-    /// (block-height vs. time) than an input's CLTV, it is ignored — a height-based `min_locktime`
-    /// will not be combined with a time-based CLTV (and vice versa).
-    pub min_locktime: absolute::LockTime,
-
-    /// Whether to require the full tx, aka [`non_witness_utxo`] for segwit v0 inputs.
-    ///
-    /// Default is `true`.
-    ///
-    /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
-    pub mandate_full_tx_for_segwit_v0: bool,
-
-    /// Apply BIP-326 anti-fee-sniping (AFS) protection, using the given block height.
-    ///
-    /// * `None` (default) — no AFS is applied.
-    /// * `Some(tip_height)` — AFS is applied with `tip_height` as the current chain tip.
-    ///
-    /// AFS discourages miners from reorganizing recent blocks to capture fees by constraining the
-    /// transaction to only be valid at or after the chain tip. When enabled,
-    /// [`TxTemplate::create_psbt`] sets either the transaction's `nLockTime` or the `nSequence` of
-    /// one Taproot input to a value derived from `tip_height`.
-    ///
-    /// AFS only operates on a height-based `tx.lock_time`. If [`min_locktime`] or any input's
-    /// CLTV is time-based, enabling AFS produces [`AntiFeeSnipingError::UnsupportedLockTime`].
-    ///
-    /// If `tx.lock_time` is already a block height greater than `tip_height` (e.g., because an
-    /// input's CLTV pins the tx to a future block), AFS leaves the transaction unchanged — the
-    /// existing CLTV already provides equivalent protection.
-    ///
-    /// # Errors
-    ///
-    /// When `Some(..)`, [`TxTemplate::create_psbt`] returns [`CreatePsbtError::AntiFeeSniping`] if:
-    /// - the transaction version is less than 2
-    ///   ([`AntiFeeSnipingError::UnsupportedVersion`]) — v2 is required for relative locktimes; or
-    /// - a time-based (MTP) locktime is in effect
-    ///   ([`AntiFeeSnipingError::UnsupportedLockTime`]) — AFS only supports height-based locktimes.
-    ///
-    /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki) for more details.
-    ///
-    /// [`min_locktime`]: Self::min_locktime
-    pub anti_fee_sniping: Option<absolute::Height>,
-}
-
-impl Default for PsbtParams {
-    fn default() -> Self {
-        Self {
-            version: transaction::Version::TWO,
-            min_locktime: absolute::LockTime::ZERO,
-            mandate_full_tx_for_segwit_v0: true,
-            anti_fee_sniping: None,
+impl Display for SetVersionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RelativeTimelockRequiresV2 { attempted } => write!(
+                f,
+                "version {attempted} is invalid: an input has a relative timelock, which requires version >= 2 (BIP-68)",
+            ),
         }
     }
 }
 
-/// Occurs when creating a psbt fails.
+#[cfg(feature = "std")]
+impl std::error::Error for SetVersionError {}
+
+/// Error returned by [`TxTemplate::set_locktime`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum SetLockTimeError {
+    /// The provided lock_time is below an input's required CLTV.
+    BelowInputCltv {
+        /// CLTV required by an input.
+        required: absolute::LockTime,
+        /// LockTime the caller attempted to set.
+        attempted: absolute::LockTime,
+    },
+    /// The provided lock_time uses a different unit (block-height vs. time) than an input's CLTV.
+    UnitMismatch {
+        /// CLTV required by an input.
+        input: absolute::LockTime,
+        /// LockTime the caller attempted to set.
+        attempted: absolute::LockTime,
+    },
+}
+
+impl Display for SetLockTimeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BelowInputCltv {
+                required,
+                attempted,
+            } => write!(
+                f,
+                "lock_time {attempted} is below an input's required CLTV {required}",
+            ),
+            Self::UnitMismatch { input, attempted } => write!(
+                f,
+                "lock_time {attempted} has a different unit than an input's CLTV {input}",
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SetLockTimeError {}
+
+/// A fully-resolved tx shape — the workspace between coin selection and the final [`Psbt`]
+/// or [`Transaction`].
+///
+/// Typically obtained from [`Selector::try_finalize`] (or
+/// [`InputCandidates::into_tx_template`]). Exposes the operations that *shape* the resulting
+/// transaction: input/output ordering, anti-fee-sniping, version/locktime overrides, and
+/// final emission to PSBT or [`Transaction`].
+///
+/// New templates start with `version = TWO`, `lock_time = max(input CLTVs)` (or `ZERO`), and
+/// `fallback_sequence = ENABLE_RBF_NO_LOCKTIME`.
+///
+/// [`Selector::try_finalize`]: crate::Selector::try_finalize
+/// [`InputCandidates::into_tx_template`]: crate::InputCandidates::into_tx_template
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct TxTemplate {
+    version: transaction::Version,
+    lock_time: absolute::LockTime,
+    fallback_sequence: Sequence,
+    inputs: Vec<Input>,
+    outputs: Vec<Output>,
+}
+
+/// Parameters for emitting a [`Psbt`] from a [`TxTemplate`].
+///
+/// Carries only PSBT-specific options. Transaction-shape decisions (version, locktime,
+/// sequence, anti-fee-sniping, input/output ordering) all live on [`TxTemplate`].
+#[derive(Debug, Clone)]
+pub struct PsbtBuildParams {
+    /// Whether to require the full tx (aka [`non_witness_utxo`]) for segwit v0 inputs.
+    ///
+    /// Default: `true`.
+    ///
+    /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
+    pub mandate_full_tx_for_segwit_v0: bool,
+}
+
+impl Default for PsbtBuildParams {
+    fn default() -> Self {
+        Self {
+            mandate_full_tx_for_segwit_v0: true,
+        }
+    }
+}
+
+/// Error returned by [`TxTemplate::create_psbt`].
 #[derive(Debug)]
-pub enum CreatePsbtError {
+pub enum BuildPsbtError {
     /// Missing tx for legacy input.
     MissingFullTxForLegacyInput(Box<Input>),
     /// Missing tx for segwit v0 input.
@@ -95,61 +150,138 @@ pub enum CreatePsbtError {
     Psbt(bitcoin::psbt::Error),
     /// Update psbt output with descriptor error.
     OutputUpdate(miniscript::psbt::OutputUpdateError),
-    /// Occurs when applying anti-fee-sniping fails.
-    AntiFeeSniping(AntiFeeSnipingError),
 }
 
-impl From<AntiFeeSnipingError> for CreatePsbtError {
-    fn from(e: AntiFeeSnipingError) -> Self {
-        Self::AntiFeeSniping(e)
-    }
-}
-
-impl core::fmt::Display for CreatePsbtError {
+impl Display for BuildPsbtError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            CreatePsbtError::MissingFullTxForLegacyInput(input) => write!(
+            Self::MissingFullTxForLegacyInput(input) => write!(
                 f,
                 "legacy input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
                 input.prev_outpoint()
             ),
-            CreatePsbtError::MissingFullTxForSegwitV0Input(input) => write!(
+            Self::MissingFullTxForSegwitV0Input(input) => write!(
                 f,
                 "segwit v0 input that spends {} requires PSBT_IN_NON_WITNESS_UTXO",
                 input.prev_outpoint()
             ),
-            CreatePsbtError::Psbt(error) => Display::fmt(&error, f),
-            CreatePsbtError::OutputUpdate(output_update_error) => {
-                Display::fmt(&output_update_error, f)
-            }
-            CreatePsbtError::AntiFeeSniping(e) => Display::fmt(e, f),
+            Self::Psbt(e) => Display::fmt(e, f),
+            Self::OutputUpdate(e) => Display::fmt(e, f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CreatePsbtError {}
+impl std::error::Error for BuildPsbtError {}
 
 impl TxTemplate {
     pub(crate) fn from_parts(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
-        Self { inputs, outputs }
+        let lock_time = max_input_cltv(&inputs).unwrap_or(absolute::LockTime::ZERO);
+        Self {
+            version: transaction::Version::TWO,
+            lock_time,
+            fallback_sequence: FALLBACK_SEQUENCE,
+            inputs,
+            outputs,
+        }
     }
 
-    /// Inputs in this selection.
+    /// Resolved transaction version.
+    pub fn version(&self) -> transaction::Version {
+        self.version
+    }
+
+    /// Override `tx.version`.
+    ///
+    /// Default is [`transaction::Version::TWO`]. Setting a different value is allowed only when
+    /// no input has a relative timelock (BIP-68 requires v2 in that case).
+    ///
+    /// # Errors
+    ///
+    /// - [`SetVersionError::RelativeTimelockRequiresV2`] if `version < 2` and any input has a
+    ///   relative timelock.
+    pub fn set_version(mut self, version: transaction::Version) -> Result<Self, SetVersionError> {
+        if version < transaction::Version::TWO
+            && self.inputs.iter().any(|i| i.relative_timelock().is_some())
+        {
+            return Err(SetVersionError::RelativeTimelockRequiresV2 { attempted: version });
+        }
+        self.version = version;
+        Ok(self)
+    }
+
+    /// Resolved transaction lock_time.
+    pub fn lock_time(&self) -> absolute::LockTime {
+        self.lock_time
+    }
+
+    /// Set the fallback `nSequence` used for inputs that don't specify their own.
+    ///
+    /// The fallback is applied lazily at materialization (in [`Self::to_unsigned_tx`] and
+    /// [`Self::create_psbt`]); calling this method after other transformations does not
+    /// retroactively change inputs whose sequence has already been set explicitly (e.g. by
+    /// [`apply_anti_fee_sniping`](Self::apply_anti_fee_sniping)).
+    pub fn set_fallback_sequence(mut self, sequence: Sequence) -> Self {
+        self.fallback_sequence = sequence;
+        self
+    }
+
+    /// Override `tx.lock_time`.
+    ///
+    /// Returns an error if `lock_time` would conflict with an input's required CLTV
+    /// (either by being below the requirement, or by using a different unit).
+    ///
+    /// Setting `lock_time` to a non-zero value when *every* input has `nSequence::MAX`
+    /// is *not* rejected, but per BIP-65 / Bitcoin's `IsFinalTx` rule the lock_time will
+    /// then be ignored at validation time.
+    ///
+    /// # Errors
+    ///
+    /// - [`SetLockTimeError::BelowInputCltv`] if `lock_time < required` (same unit).
+    /// - [`SetLockTimeError::UnitMismatch`] if `lock_time` is height-based and an input's
+    ///   CLTV is time-based (or vice versa).
+    pub fn set_locktime(mut self, lock_time: absolute::LockTime) -> Result<Self, SetLockTimeError> {
+        for input in &self.inputs {
+            let Some(required) = input.absolute_timelock() else {
+                continue;
+            };
+            if !required.is_same_unit(lock_time) {
+                return Err(SetLockTimeError::UnitMismatch {
+                    input: required,
+                    attempted: lock_time,
+                });
+            }
+            if !required.is_implied_by(lock_time) {
+                return Err(SetLockTimeError::BelowInputCltv {
+                    required,
+                    attempted: lock_time,
+                });
+            }
+        }
+        self.lock_time = lock_time;
+        Ok(self)
+    }
+
+    /// Fallback `nSequence` applied to inputs that don't specify their own.
+    pub fn fallback_sequence(&self) -> Sequence {
+        self.fallback_sequence
+    }
+
+    /// Inputs in this template.
     pub fn inputs(&self) -> &[Input] {
         &self.inputs
     }
 
-    /// Outputs in this selection.
+    /// Outputs in this template.
     pub fn outputs(&self) -> &[Output] {
         &self.outputs
     }
 
     /// Mutable handle to the input spending `outpoint`, if any.
     ///
-    /// Returns [`None`] if no input in this selection spends `outpoint`. The returned
-    /// [`InputMut`] only permits mutations that preserve the selection's coin-selection
-    /// invariants — see [`InputMut`] for the available operations.
+    /// Returns [`None`] if no input in this template spends `outpoint`. The returned
+    /// [`InputMut`] only permits mutations that preserve the template's invariants — see
+    /// [`InputMut`] for the available operations.
     pub fn input_mut(&mut self, outpoint: OutPoint) -> Option<InputMut<'_>> {
         self.inputs
             .iter_mut()
@@ -157,124 +289,115 @@ impl TxTemplate {
             .map(InputMut::new)
     }
 
-    /// Iterator yielding a mutable handle to every input in this selection.
+    /// Iterator yielding a mutable handle to every input in this template.
     ///
-    /// Each yielded [`InputMut`] only permits mutations that preserve the selection's
-    /// coin-selection invariants — see [`InputMut`] for the available operations.
+    /// Each yielded [`InputMut`] only permits mutations that preserve the template's
+    /// invariants — see [`InputMut`] for the available operations.
     pub fn inputs_mut(&mut self) -> impl Iterator<Item = InputMut<'_>> {
         self.inputs.iter_mut().map(InputMut::new)
     }
 
-    /// Reorder inputs in-place using `compare`.
+    /// Reorder inputs using `compare`. Uses a stable sort.
     ///
-    /// Uses a stable sort: inputs that compare equal retain their relative order.
     /// Typical use is BIP-69 lexicographic ordering by previous outpoint.
-    pub fn sort_inputs_by<F>(&mut self, compare: F)
+    pub fn sort_inputs_by<F>(mut self, compare: F) -> Self
     where
         F: FnMut(&Input, &Input) -> Ordering,
     {
         self.inputs.sort_by(compare);
+        self
     }
 
-    /// Randomly shuffle inputs in-place using `rng`.
+    /// Randomly shuffle inputs using `rng`.
     ///
     /// Useful for chain-analysis resistance when no deterministic ordering is required.
-    pub fn shuffle_inputs<R: RngCore>(&mut self, rng: &mut R) {
+    pub fn shuffle_inputs<R: RngCore>(mut self, rng: &mut R) -> Self {
         fisher_yates_shuffle(&mut self.inputs, rng);
+        self
     }
 
-    /// Reorder outputs in-place using `compare`.
+    /// Reorder outputs using `compare`. Uses a stable sort.
     ///
-    /// Uses a stable sort: outputs that compare equal retain their relative order.
     /// Typical use is BIP-69 (ascending by amount, then by `script_pubkey`).
-    pub fn sort_outputs_by<F>(&mut self, compare: F)
+    pub fn sort_outputs_by<F>(mut self, compare: F) -> Self
     where
         F: FnMut(&Output, &Output) -> Ordering,
     {
         self.outputs.sort_by(compare);
+        self
     }
 
-    /// Randomly shuffle outputs in-place using `rng`.
+    /// Randomly shuffle outputs using `rng`.
     ///
-    /// Useful for chain-analysis resistance — in particular, hiding which output
-    /// is the change.
-    pub fn shuffle_outputs<R: RngCore>(&mut self, rng: &mut R) {
+    /// Useful for chain-analysis resistance — in particular, hiding which output is the
+    /// change.
+    pub fn shuffle_outputs<R: RngCore>(mut self, rng: &mut R) -> Self {
         fisher_yates_shuffle(&mut self.outputs, rng);
+        self
     }
 
-    /// Accumulates the maximum locktime from an iterator of input-required locktimes.
+    /// Materialize the unsigned `bitcoin::Transaction` represented by this template.
     ///
-    /// Returns `min_locktime` if the locktimes iterator is empty, otherwise the maximum locktime
-    /// across the inputs (with `min_locktime` only applied when compatible with the inputs' unit).
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `locktimes` contains values with different units (height vs.
-    /// time). `Selector::new` rejects such candidates upstream, so this should never fire in
-    /// practice.
-    fn accumulate_max_locktime(
-        locktimes: impl IntoIterator<Item = absolute::LockTime>,
-        min_locktime: absolute::LockTime,
-    ) -> absolute::LockTime {
-        // Accumulate locktimes required by inputs. An input-vs-input unit mismatch is rejected
-        // upstream by `Selector::new`. `min_locktime` is only used when it is compatible with
-        // the input requirements; a different unit is intentionally ignored so that, e.g., a
-        // height-based `min_locktime` does not conflict with a time-based CLTV requirement.
-        let inputs_max = locktimes.into_iter().reduce(|a, b| {
-            debug_assert!(
-                a.is_same_unit(b),
-                "Selector::new should reject mixed-unit candidates",
-            );
-            if a.is_implied_by(b) {
-                b
-            } else {
-                a
-            }
-        });
-        match inputs_max {
-            Some(lt) if lt.is_implied_by(min_locktime) => min_locktime,
-            Some(lt) => lt,
-            None => min_locktime,
-        }
-    }
-
-    /// Create PSBT.
-    #[cfg(feature = "std")]
-    pub fn create_psbt(&self, params: PsbtParams) -> Result<bitcoin::Psbt, CreatePsbtError> {
-        self.create_psbt_with_rng(params, &mut rand::thread_rng())
-    }
-
-    /// Create PSBT with `rng`.
-    pub fn create_psbt_with_rng(
-        &self,
-        params: PsbtParams,
-        rng: &mut impl RngCore,
-    ) -> Result<bitcoin::Psbt, CreatePsbtError> {
-        let mut tx = bitcoin::Transaction {
-            version: params.version,
-            lock_time: Self::accumulate_max_locktime(
-                self.inputs
-                    .iter()
-                    .filter_map(|input| input.absolute_timelock()),
-                params.min_locktime,
-            ),
+    /// Each input's `nSequence` is its own [`Input::sequence`] if set, otherwise
+    /// [`fallback_sequence`](Self::fallback_sequence).
+    pub fn to_unsigned_tx(&self) -> Transaction {
+        Transaction {
+            version: self.version,
+            lock_time: self.lock_time,
             input: self
                 .inputs
                 .iter()
-                .map(|input| bitcoin::TxIn {
+                .map(|input| TxIn {
                     previous_output: input.prev_outpoint(),
-                    sequence: input.sequence().unwrap_or(Sequence::ENABLE_RBF_NO_LOCKTIME),
+                    sequence: input.sequence().unwrap_or(self.fallback_sequence),
                     ..Default::default()
                 })
                 .collect(),
-            output: self.outputs.iter().map(|output| output.txout()).collect(),
-        };
+            output: self.outputs.iter().map(Output::txout).collect(),
+        }
+    }
 
-        if let Some(tip_height) = params.anti_fee_sniping {
-            apply_anti_fee_sniping(&mut tx, &self.inputs, tip_height, rng)?;
-        };
+    /// Apply BIP-326 anti-fee-sniping (AFS) protection using `tip_height` as the chain tip.
+    ///
+    /// AFS discourages miners from reorganizing recent blocks to capture fees by constraining
+    /// the transaction to only be valid at or after the chain tip. This sets either
+    /// `tx.lock_time` (via [`set_locktime`](Self::set_locktime)) or the `nSequence` of one
+    /// Taproot input (via [`Input::set_sequence`]).
+    ///
+    /// AFS only operates on a height-based `tx.lock_time`. If any input's CLTV is time-based,
+    /// this returns [`AntiFeeSnipingError::UnsupportedLockTime`].
+    ///
+    /// If `tx.lock_time` is already a block height greater than `tip_height` (e.g., because an
+    /// input's CLTV pins the tx to a future block), this leaves the template unchanged.
+    ///
+    /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki).
+    ///
+    /// # Errors
+    ///
+    /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `version < 2`.
+    /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `lock_time` is time-based.
+    pub fn apply_anti_fee_sniping<R: RngCore>(
+        self,
+        tip_height: absolute::Height,
+        rng: &mut R,
+    ) -> Result<Self, AntiFeeSnipingError> {
+        apply_anti_fee_sniping(self, tip_height, rng)
+    }
 
-        let mut psbt = Psbt::from_unsigned_tx(tx).map_err(CreatePsbtError::Psbt)?;
+    /// Build the [`Psbt`] and its associated [`Finalizer`].
+    #[cfg(feature = "std")]
+    pub fn create_psbt(self, params: PsbtBuildParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
+        self.create_psbt_with_rng(params, &mut rand::thread_rng())
+    }
+
+    /// Build the [`Psbt`] and its associated [`Finalizer`] with a custom `rng`.
+    pub fn create_psbt_with_rng(
+        self,
+        params: PsbtBuildParams,
+        _rng: &mut impl RngCore,
+    ) -> Result<(Psbt, Finalizer), BuildPsbtError> {
+        let tx = self.to_unsigned_tx();
+        let mut psbt = Psbt::from_unsigned_tx(tx).map_err(BuildPsbtError::Psbt)?;
 
         for (plan_input, psbt_input) in self.inputs.iter().zip(psbt.inputs.iter_mut()) {
             if let Some(finalized_psbt_input) = plan_input.psbt_input() {
@@ -288,47 +411,64 @@ impl TxTemplate {
                 if witness_version.is_some() {
                     psbt_input.witness_utxo = Some(plan_input.prev_txout().clone());
                 }
-                // We are allowed to have full tx for segwit inputs. Might as well include it.
-                // If the caller does not wish to include the full tx in Segwit V0 inputs, they should not
-                // include it in `crate::Input`.
                 psbt_input.non_witness_utxo = plan_input.prev_tx().cloned();
                 if psbt_input.non_witness_utxo.is_none() {
                     if witness_version.is_none() {
-                        return Err(CreatePsbtError::MissingFullTxForLegacyInput(Box::new(
+                        return Err(BuildPsbtError::MissingFullTxForLegacyInput(Box::new(
                             plan_input.clone(),
                         )));
                     }
                     if params.mandate_full_tx_for_segwit_v0
                         && witness_version == Some(bitcoin::WitnessVersion::V0)
                     {
-                        return Err(CreatePsbtError::MissingFullTxForSegwitV0Input(Box::new(
+                        return Err(BuildPsbtError::MissingFullTxForSegwitV0Input(Box::new(
                             plan_input.clone(),
                         )));
                     }
                 }
-
                 continue;
             }
             unreachable!("input candidate must either have finalized psbt input or plan");
         }
+
         for (output_index, output) in self.outputs.iter().enumerate() {
             if let Some(desc) = output.descriptor() {
                 psbt.update_output_with_descriptor(output_index, desc)
-                    .map_err(CreatePsbtError::OutputUpdate)?;
+                    .map_err(BuildPsbtError::OutputUpdate)?;
             }
         }
 
-        Ok(psbt)
-    }
+        let finalizer = Finalizer::new(self.inputs.into_iter().filter_map(|input| {
+            let outpoint = input.prev_outpoint();
+            let plan = input.plan().cloned()?;
+            Some((outpoint, plan))
+        }));
 
-    /// Into psbt finalizer.
-    pub fn into_finalizer(self) -> Finalizer {
-        Finalizer::new(
-            self.inputs
-                .iter()
-                .filter_map(|input| Some((input.prev_outpoint(), input.plan().cloned()?))),
-        )
+        Ok((psbt, finalizer))
     }
+}
+
+/// Maximum CLTV requirement across `inputs`, or `None` if no input has a CLTV.
+///
+/// # Panics
+///
+/// In debug builds, panics if inputs have CLTVs of different units (height vs. time).
+/// `Selector::new` rejects such candidates upstream, so this should never fire in practice.
+fn max_input_cltv(inputs: &[Input]) -> Option<absolute::LockTime> {
+    inputs
+        .iter()
+        .filter_map(Input::absolute_timelock)
+        .reduce(|a, b| {
+            debug_assert!(
+                a.is_same_unit(b),
+                "Selector::new should reject mixed-unit candidates",
+            );
+            if a.is_implied_by(b) {
+                b
+            } else {
+                a
+            }
+        })
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -339,10 +479,11 @@ mod tests {
         absolute::{self, LockTime, Time},
         relative,
         secp256k1::Secp256k1,
-        transaction::{self, Version},
-        Amount, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        transaction::Version,
+        Amount, ScriptBuf, Transaction, TxIn, TxOut,
     };
     use miniscript::{plan::Assets, Descriptor, DescriptorPublicKey};
+    use rand::thread_rng;
     use rand_core::OsRng;
 
     const TEST_DESCRIPTOR: &str = "tr([83737d5e/86h/1h/0h]tpubDDR5GgtoxS8fJyjjvdahN4VzV5DV6jtbcyvVXhEKq2XtpxjxBXmxH3r8QrNbQqHg4bJM1EGkxi7Pjfkgnui9jQWqS7kxHvX6rhUeriLDKxz/0/*)";
@@ -361,7 +502,7 @@ mod tests {
             .plan(&Assets::new().add(desc_pk).after(cltv))
             .unwrap();
         let prev_tx = Transaction {
-            version: transaction::Version::TWO,
+            version: Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::default()],
             output: vec![TxOut {
@@ -373,104 +514,7 @@ mod tests {
         Ok((input, desc))
     }
 
-    #[test]
-    fn test_min_locktime_height() -> anyhow::Result<()> {
-        let abs_locktime = absolute::LockTime::from_consensus(100_000);
-
-        let (input, desc) = setup_cltv_input(abs_locktime)?;
-
-        let selection = TxTemplate::from_parts(
-            vec![input],
-            vec![Output::with_descriptor(
-                desc.at_derivation_index(1)?,
-                Amount::from_sat(1000),
-            )],
-        );
-
-        struct TestCase {
-            name: &'static str,
-            psbt_params: PsbtParams,
-            exp_locktime: u32,
-        }
-
-        let cases = vec![
-            TestCase {
-                name: "no min_locktime, use plan locktime",
-                psbt_params: PsbtParams::default(),
-                exp_locktime: 100_000,
-            },
-            TestCase {
-                name: "larger min_locktime is used",
-                psbt_params: PsbtParams {
-                    min_locktime: absolute::LockTime::from_consensus(100_100),
-                    ..Default::default()
-                },
-                exp_locktime: 100_100,
-            },
-            TestCase {
-                name: "smaller min_locktime is ignored",
-                psbt_params: PsbtParams {
-                    min_locktime: absolute::LockTime::from_consensus(99_900),
-                    ..Default::default()
-                },
-                exp_locktime: 100_000,
-            },
-        ];
-
-        for test in cases {
-            let psbt = selection.create_psbt(test.psbt_params)?;
-            assert_eq!(
-                psbt.unsigned_tx.lock_time.to_consensus_u32(),
-                test.exp_locktime,
-                "Test failed {}",
-                test.name,
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Tests that a height-based `min_locktime` is ignored when the input
-    /// requires a time-based (UNIX timestamp) CLTV, and that an explicit time-based
-    /// `min_locktime` greater than the requirement is respected.
-    #[test]
-    fn test_min_locktime_respects_lock_type() -> anyhow::Result<()> {
-        let time_locktime = absolute::LockTime::from_consensus(1_734_230_218);
-
-        let (input, desc) = setup_cltv_input(time_locktime)?;
-
-        let selection = TxTemplate::from_parts(
-            vec![input],
-            vec![Output::with_descriptor(
-                desc.at_derivation_index(1)?,
-                Amount::from_sat(1000),
-            )],
-        );
-
-        // Default `min_locktime` is height 0 (block-height unit). It is incompatible with
-        // the time-based CLTV requirement, so it must be ignored.
-        let psbt = selection.create_psbt(PsbtParams::default())?;
-        assert_eq!(
-            psbt.unsigned_tx.lock_time, time_locktime,
-            "time-based CLTV requirement should be used; height-based `min_locktime` must be ignored",
-        );
-
-        // An explicit time-based `min_locktime` *greater* than the requirement should be respected.
-        let larger_time = absolute::LockTime::from_consensus(1_772_167_108);
-        assert!(larger_time > time_locktime);
-        let psbt = selection.create_psbt(PsbtParams {
-            min_locktime: larger_time,
-            ..Default::default()
-        })?;
-        assert_eq!(
-            psbt.unsigned_tx.lock_time, larger_time,
-            "a larger time-based `min_locktime` should override the CLTV requirement",
-        );
-
-        Ok(())
-    }
-
-    pub fn setup_test_input(confirmation_height: u32) -> anyhow::Result<Input> {
+    fn setup_test_input(confirmation_height: u32) -> anyhow::Result<Input> {
         let secp = Secp256k1::new();
         let desc = Descriptor::parse_descriptor(&secp, TEST_DESCRIPTOR)
             .unwrap()
@@ -482,7 +526,7 @@ mod tests {
         let plan = def_desc.plan(&assets).expect("failed to create plan");
 
         let prev_tx = Transaction {
-            version: transaction::Version::TWO,
+            version: Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![TxIn::default()],
             output: vec![TxOut {
@@ -496,26 +540,117 @@ mod tests {
             prev_mtp: Some(Time::from_consensus(500_000_000)?),
         };
 
-        let input = Input::from_prev_tx(plan, prev_tx, 0, Some(status))?;
-
-        Ok(input)
+        Ok(Input::from_prev_tx(plan, prev_tx, 0, Some(status))?)
     }
 
+    /// Construction takes lock_time from the input CLTV; `set_locktime` bumps it above.
     #[test]
-    fn test_anti_fee_sniping_disabled() -> anyhow::Result<()> {
+    fn set_locktime_height_above_input_cltv() -> anyhow::Result<()> {
+        let cltv = absolute::LockTime::from_consensus(100_000);
+        let (input, desc) = setup_cltv_input(cltv)?;
+        let selection = TxTemplate::from_parts(
+            vec![input],
+            vec![Output::with_descriptor(
+                desc.at_derivation_index(1)?,
+                Amount::from_sat(1000),
+            )],
+        );
+
+        let template = selection.clone();
+        assert_eq!(
+            template.lock_time(),
+            cltv,
+            "construction takes lock_time from input CLTV"
+        );
+
+        let higher = absolute::LockTime::from_consensus(100_100);
+        let bumped = selection.set_locktime(higher)?;
+        assert_eq!(bumped.lock_time(), higher);
+
+        Ok(())
+    }
+
+    /// `set_locktime` rejects values below an input's CLTV requirement.
+    #[test]
+    fn set_locktime_below_input_cltv_errors() -> anyhow::Result<()> {
+        let cltv = absolute::LockTime::from_consensus(100_000);
+        let (input, desc) = setup_cltv_input(cltv)?;
+        let selection = TxTemplate::from_parts(
+            vec![input],
+            vec![Output::with_descriptor(
+                desc.at_derivation_index(1)?,
+                Amount::from_sat(1000),
+            )],
+        );
+
+        let too_low = absolute::LockTime::from_consensus(99_999);
+        let result = selection.set_locktime(too_low);
+
+        assert!(matches!(
+            result,
+            Err(SetLockTimeError::BelowInputCltv { required, attempted })
+                if required == cltv && attempted == too_low
+        ));
+        Ok(())
+    }
+
+    /// A time-based input CLTV propagates to the template's lock_time at construction.
+    #[test]
+    fn lock_time_takes_time_based_cltv_from_input() -> anyhow::Result<()> {
+        let time_locktime = absolute::LockTime::from_consensus(1_734_230_218);
+        let (input, desc) = setup_cltv_input(time_locktime)?;
+        let selection = TxTemplate::from_parts(
+            vec![input],
+            vec![Output::with_descriptor(
+                desc.at_derivation_index(1)?,
+                Amount::from_sat(1000),
+            )],
+        );
+
+        assert_eq!(selection.lock_time(), time_locktime);
+
+        Ok(())
+    }
+
+    /// `set_locktime` errors when the supplied unit conflicts with an input's CLTV unit.
+    #[test]
+    fn set_locktime_unit_mismatch_errors() -> anyhow::Result<()> {
+        let height_cltv = absolute::LockTime::from_consensus(100_000);
+        let (input, desc) = setup_cltv_input(height_cltv)?;
+        let selection = TxTemplate::from_parts(
+            vec![input],
+            vec![Output::with_descriptor(
+                desc.at_derivation_index(1)?,
+                Amount::from_sat(1000),
+            )],
+        );
+
+        let time_attempt = absolute::LockTime::from_consensus(1_734_230_218);
+        let result = selection.set_locktime(time_attempt);
+
+        assert!(matches!(
+            result,
+            Err(SetLockTimeError::UnitMismatch { input, attempted })
+                if input == height_cltv && attempted == time_attempt
+        ));
+        Ok(())
+    }
+
+    /// `set_locktime` propagates the chosen value through PSBT creation.
+    #[test]
+    fn set_locktime_propagates_to_psbt() -> anyhow::Result<()> {
         let current_height = 2_500;
-        let input = setup_test_input(2_000).unwrap();
+        let input = setup_test_input(2_000)?;
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
         let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
-        // Disabled - default behavior is disable
-        let psbt = selection.create_psbt(PsbtParams {
-            min_locktime: absolute::LockTime::from_consensus(current_height),
-            ..Default::default()
-        })?;
-        let tx = psbt.unsigned_tx;
-        assert_eq!(tx.lock_time.to_consensus_u32(), current_height);
-
+        let (psbt, _) = selection
+            .set_locktime(absolute::LockTime::from_consensus(current_height))?
+            .create_psbt(PsbtBuildParams::default())?;
+        assert_eq!(
+            psbt.unsigned_tx.lock_time.to_consensus_u32(),
+            current_height
+        );
         Ok(())
     }
 
@@ -533,10 +668,9 @@ mod tests {
             let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
             let selection = TxTemplate::from_parts(vec![input.clone()], vec![output]);
 
-            let psbt = selection.create_psbt(PsbtParams {
-                anti_fee_sniping: Some(tip),
-                ..Default::default()
-            })?;
+            let (psbt, _) = selection
+                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .create_psbt(PsbtBuildParams::default())?;
 
             let tx = psbt.unsigned_tx;
 
@@ -545,19 +679,14 @@ mod tests {
                 let locktime_value = tx.lock_time.to_consensus_u32();
                 let min_height = current_height.saturating_sub(100);
                 assert!((min_height..=current_height).contains(&locktime_value));
-                assert!(locktime_value <= current_height);
-                assert!(locktime_value >= current_height.saturating_sub(100));
             } else {
                 used_sequence = true;
                 let sequence_value = tx.input[0].sequence.to_consensus_u32();
                 let confirmations =
                     input.confirmations(absolute::Height::from_consensus(current_height).unwrap());
-
                 let min_sequence = confirmations.saturating_sub(100);
                 assert!((min_sequence..=confirmations).contains(&sequence_value));
                 assert!(sequence_value >= 1, "Sequence must be at least 1");
-                assert!(sequence_value <= confirmations);
-                assert!(sequence_value >= confirmations.saturating_sub(100));
             }
 
             loops += 1;
@@ -584,11 +713,10 @@ mod tests {
                 vec![input1.clone(), input2.clone(), input3.clone()],
                 vec![output.clone()],
             );
-            let psbt = selection
-                .create_psbt(PsbtParams {
-                    anti_fee_sniping: Some(tip),
-                    ..Default::default()
-                })
+            let (psbt, _) = selection
+                .apply_anti_fee_sniping(tip, &mut thread_rng())
+                .unwrap()
+                .create_psbt(PsbtBuildParams::default())
                 .unwrap();
 
             let tx = psbt.unsigned_tx;
@@ -597,7 +725,6 @@ mod tests {
                 used_locktime = true;
             } else {
                 used_sequence = true;
-                // One of the inputs should have modified sequence
                 let has_modified_sequence = tx.input.iter().any(|txin| {
                     let seq = txin.sequence.to_consensus_u32();
                     seq > 0 && seq < 65_535
@@ -613,13 +740,12 @@ mod tests {
         }
     }
 
-    /// Regression: pre-fix, the AFS nLockTime path could overwrite `tx.lock_time` with a value
+    /// Regression: pre-fix, AFS's nLockTime path could overwrite `tx.lock_time` with a value
     /// lower than an input's required CLTV.
     #[test]
     fn test_anti_fee_sniping_preserves_input_cltv() -> anyhow::Result<()> {
         let cltv = absolute::LockTime::from_consensus(100_000);
         let (input, desc) = setup_cltv_input(cltv)?;
-        // Tip is well below the input's CLTV requirement.
         let tip = absolute::Height::from_consensus(50_000)?;
 
         let selection = TxTemplate::from_parts(
@@ -630,13 +756,11 @@ mod tests {
             )],
         );
 
-        // The input is wsh (not Taproot), so AFS deterministically takes the locktime path; loop a
-        // few times anyway as cheap insurance against future control-flow changes.
         for _ in 0..100 {
-            let psbt = selection.create_psbt(PsbtParams {
-                anti_fee_sniping: Some(tip),
-                ..Default::default()
-            })?;
+            let (psbt, _) = selection
+                .clone()
+                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .create_psbt(PsbtBuildParams::default())?;
             assert_eq!(
                 psbt.unsigned_tx.lock_time, cltv,
                 "AFS must not overwrite an input's CLTV with a lower value",
@@ -654,9 +778,9 @@ mod tests {
     fn test_anti_fee_sniping_sequence_path_requires_zero_locktime() -> anyhow::Result<()> {
         let tip = absolute::Height::from_consensus(3_000)?;
         // Below the AFS target, so it does not otherwise interfere with the locktime path.
-        let min_locktime = absolute::LockTime::from_consensus(2_000);
+        let lock_time = absolute::LockTime::from_consensus(2_000);
 
-        // A confirmed Taproot input with no CSV: without `min_locktime` this would make the
+        // A confirmed Taproot input with no CSV: without the locktime this would make the
         // nSequence path reachable, so the test also guards against the fix being a no-op.
         let input = setup_test_input(2_500)?;
 
@@ -669,11 +793,11 @@ mod tests {
         );
 
         for _ in 0..100 {
-            let psbt = selection.create_psbt(PsbtParams {
-                min_locktime,
-                anti_fee_sniping: Some(tip),
-                ..Default::default()
-            })?;
+            let (psbt, _) = selection
+                .clone()
+                .set_locktime(lock_time)?
+                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .create_psbt(PsbtBuildParams::default())?;
             let tx = psbt.unsigned_tx;
 
             assert_eq!(
@@ -692,22 +816,16 @@ mod tests {
         Ok(())
     }
 
-    /// Regression: pre-fix, the AFS nSequence path could pick a Taproot input that already carried
-    /// a CSV (relative-timelock) requirement and overwrite its sequence. The presence of a regular
-    /// Taproot input ensures the sequence path remains reachable — so the test also catches a
-    /// regression where AFS degrades to "never use the sequence path."
+    /// Regression: pre-fix, AFS's nSequence path could pick a Taproot input that already carried
+    /// a CSV (relative-timelock) requirement and overwrite its sequence.
     #[test]
     fn test_anti_fee_sniping_skips_taproot_csv_input() -> anyhow::Result<()> {
         let tip = absolute::Height::from_consensus(3_000)?;
         let csv_blocks = 10;
 
-        // Input A: regular Taproot, no CSV.
         let regular_input = setup_test_input(2_500)?;
         let regular_outpoint = regular_input.prev_outpoint();
 
-        // Input B: Taproot whose script-path requires CSV. The internal key is omitted from
-        // `assets`, forcing planning to use the script-path leaf (which sets
-        // `plan.relative_timelock`).
         let secp = Secp256k1::new();
         let desc_str =
             format!("tr({TEST_HEX_PK},and_v(v:pk({TEST_DESCRIPTOR_PK}),older({csv_blocks})))");
@@ -737,8 +855,6 @@ mod tests {
 
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(18_000));
 
-        // We will run AFS for 100 rounds.
-        // Track whether AFS's nSequence path actually fired for at least one of the rounds.
         let mut observed_sequence_path = false;
 
         for _ in 0..100 {
@@ -746,10 +862,9 @@ mod tests {
                 vec![regular_input.clone(), csv_input.clone()],
                 vec![output.clone()],
             );
-            let psbt = selection.create_psbt(PsbtParams {
-                anti_fee_sniping: Some(tip),
-                ..Default::default()
-            })?;
+            let (psbt, _) = selection
+                .apply_anti_fee_sniping(tip, &mut thread_rng())?
+                .create_psbt(PsbtBuildParams::default())?;
             let tx = psbt.unsigned_tx;
 
             let csv_txin = tx
@@ -767,22 +882,20 @@ mod tests {
                 .iter()
                 .find(|t| t.previous_output == regular_outpoint)
                 .expect("regular input must be present");
-            if regular_txin.sequence != Sequence::ENABLE_RBF_NO_LOCKTIME {
+            if regular_txin.sequence != FALLBACK_SEQUENCE {
                 observed_sequence_path = true;
             }
         }
 
         assert!(
             observed_sequence_path,
-            "AFS nSequence path must fire at least once across the 100 trials (otherwise the \
-            CSV-preservation check above doesn't exercise the candidate-pool exclusion)",
+            "AFS nSequence path must fire at least once across the 100 trials",
         );
 
         Ok(())
     }
 
-    /// A time-based CLTV propagates to `tx.lock_time`; AFS only supports height-based locktimes, so
-    /// it must surface `UnsupportedLockTime`.
+    /// A time-based CLTV propagates to `tx.lock_time`; AFS only supports height-based locktimes.
     #[test]
     fn test_anti_fee_sniping_rejects_time_based_locktime() -> anyhow::Result<()> {
         let time_locktime = absolute::LockTime::from_consensus(1_734_230_218);
@@ -797,51 +910,92 @@ mod tests {
             )],
         );
 
-        let result = selection.create_psbt(PsbtParams {
-            anti_fee_sniping: Some(tip),
-            ..Default::default()
-        });
+        let result = selection.apply_anti_fee_sniping(tip, &mut thread_rng());
 
         assert!(matches!(
             result,
-            Err(CreatePsbtError::AntiFeeSniping(AntiFeeSnipingError::UnsupportedLockTime(lt)))
-                if lt == time_locktime
+            Err(AntiFeeSnipingError::UnsupportedLockTime(lt)) if lt == time_locktime
         ));
 
         Ok(())
     }
 
     #[test]
-    fn test_anti_fee_sniping_unsupported_version_error() {
+    fn test_anti_fee_sniping_unsupported_version_error() -> anyhow::Result<()> {
         let confirmation_height = 800_000;
-        let input = setup_test_input(confirmation_height).unwrap();
-        let inputs = vec![input];
-        let current_height = absolute::Height::from_consensus(confirmation_height + 50).unwrap();
+        let input = setup_test_input(confirmation_height)?;
+        let current_height = absolute::Height::from_consensus(confirmation_height + 50)?;
 
-        let mut tx = Transaction {
-            version: Version::ONE,
-            lock_time: LockTime::from_height(current_height.to_consensus_u32()).unwrap(),
-            input: vec![TxIn {
-                previous_output: inputs[0].prev_outpoint(),
-                ..Default::default()
-            }],
-            output: vec![],
-        };
-
-        let result = apply_anti_fee_sniping(&mut tx, &inputs, current_height, &mut OsRng);
-
-        assert!(
-            matches!(result, Err(AntiFeeSnipingError::UnsupportedVersion(_))),
-            "should return UnsupportedVersion error for version < 2"
+        let selection = TxTemplate::from_parts(
+            vec![input],
+            vec![Output::with_script(
+                ScriptBuf::new(),
+                Amount::from_sat(9_000),
+            )],
         );
+
+        let result = selection
+            .set_version(Version::ONE)?
+            .apply_anti_fee_sniping(current_height, &mut OsRng);
+
+        assert!(matches!(
+            result,
+            Err(AntiFeeSnipingError::UnsupportedVersion(_))
+        ));
+
+        Ok(())
     }
 
+    /// `set_version` rejects v1 when any input has a relative timelock (BIP-68).
     #[test]
-    fn test_fisher_yates_shuffle_preserves_multiset() {
-        let original: Vec<u32> = (0..32).collect();
-        let mut shuffled = original.clone();
-        fisher_yates_shuffle(&mut shuffled, &mut OsRng);
-        shuffled.sort();
-        assert_eq!(shuffled, original);
+    fn set_version_below_two_with_relative_timelock_errors() -> anyhow::Result<()> {
+        let csv_blocks = 10;
+        let secp = Secp256k1::new();
+        let desc_str =
+            format!("tr({TEST_HEX_PK},and_v(v:pk({TEST_DESCRIPTOR_PK}),older({csv_blocks})))");
+        let desc = Descriptor::parse_descriptor(&secp, &desc_str)?
+            .0
+            .at_derivation_index(0)?;
+        let prev_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                script_pubkey: desc.script_pubkey(),
+                value: Amount::from_sat(10_000),
+            }],
+        };
+        let assets = Assets::new()
+            .add(TEST_DESCRIPTOR_PK.parse::<DescriptorPublicKey>()?)
+            .older(relative::LockTime::from_height(csv_blocks));
+        let plan = desc.plan(&assets).expect("script-path plan with CSV");
+        let status = crate::ConfirmationStatus {
+            height: absolute::Height::from_consensus(2_500)?,
+            prev_mtp: Some(Time::from_consensus(500_000_000)?),
+        };
+        let csv_input = Input::from_prev_tx(plan, prev_tx, 0, Some(status))?;
+
+        let selection = TxTemplate::from_parts(
+            vec![csv_input],
+            vec![Output::with_script(
+                ScriptBuf::new(),
+                Amount::from_sat(9_000),
+            )],
+        );
+
+        assert_eq!(
+            selection.version(),
+            Version::TWO,
+            "construction defaults to v2",
+        );
+
+        let result = selection.set_version(Version::ONE);
+        assert!(matches!(
+            result,
+            Err(SetVersionError::RelativeTimelockRequiresV2 { attempted })
+                if attempted == Version::ONE
+        ));
+
+        Ok(())
     }
 }

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -16,7 +16,7 @@ use crate::{
 /// Final selection of inputs and outputs.
 #[derive(Debug, Clone)]
 #[must_use]
-pub struct Selection {
+pub struct TxTemplate {
     inputs: Vec<Input>,
     outputs: Vec<Output>,
 }
@@ -49,7 +49,7 @@ pub struct PsbtParams {
     ///
     /// AFS discourages miners from reorganizing recent blocks to capture fees by constraining the
     /// transaction to only be valid at or after the chain tip. When enabled,
-    /// [`Selection::create_psbt`] sets either the transaction's `nLockTime` or the `nSequence` of
+    /// [`TxTemplate::create_psbt`] sets either the transaction's `nLockTime` or the `nSequence` of
     /// one Taproot input to a value derived from `tip_height`.
     ///
     /// AFS only operates on a height-based `tx.lock_time`. If [`min_locktime`] or any input's
@@ -61,7 +61,7 @@ pub struct PsbtParams {
     ///
     /// # Errors
     ///
-    /// When `Some(..)`, [`Selection::create_psbt`] returns [`CreatePsbtError::AntiFeeSniping`] if:
+    /// When `Some(..)`, [`TxTemplate::create_psbt`] returns [`CreatePsbtError::AntiFeeSniping`] if:
     /// - the transaction version is less than 2
     ///   ([`AntiFeeSnipingError::UnsupportedVersion`]) — v2 is required for relative locktimes; or
     /// - a time-based (MTP) locktime is in effect
@@ -130,8 +130,8 @@ impl core::fmt::Display for CreatePsbtError {
 #[cfg(feature = "std")]
 impl std::error::Error for CreatePsbtError {}
 
-impl Selection {
-    pub(crate) fn new(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
+impl TxTemplate {
+    pub(crate) fn from_parts(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
         Self { inputs, outputs }
     }
 
@@ -379,7 +379,7 @@ mod tests {
 
         let (input, desc) = setup_cltv_input(abs_locktime)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -439,7 +439,7 @@ mod tests {
 
         let (input, desc) = setup_cltv_input(time_locktime)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -506,7 +506,7 @@ mod tests {
         let current_height = 2_500;
         let input = setup_test_input(2_000).unwrap();
         let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-        let selection = Selection::new(vec![input], vec![output]);
+        let selection = TxTemplate::from_parts(vec![input], vec![output]);
 
         // Disabled - default behavior is disable
         let psbt = selection.create_psbt(PsbtParams {
@@ -531,7 +531,7 @@ mod tests {
 
         while !used_locktime || !used_sequence {
             let output = Output::with_script(ScriptBuf::new(), Amount::from_sat(9_000));
-            let selection = Selection::new(vec![input.clone()], vec![output]);
+            let selection = TxTemplate::from_parts(vec![input.clone()], vec![output]);
 
             let psbt = selection.create_psbt(PsbtParams {
                 anti_fee_sniping: Some(tip),
@@ -580,7 +580,7 @@ mod tests {
         let mut loops = 0;
 
         while !used_locktime || !used_sequence {
-            let selection = Selection::new(
+            let selection = TxTemplate::from_parts(
                 vec![input1.clone(), input2.clone(), input3.clone()],
                 vec![output.clone()],
             );
@@ -622,7 +622,7 @@ mod tests {
         // Tip is well below the input's CLTV requirement.
         let tip = absolute::Height::from_consensus(50_000)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,
@@ -660,7 +660,7 @@ mod tests {
         // nSequence path reachable, so the test also guards against the fix being a no-op.
         let input = setup_test_input(2_500)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![Output::with_script(
                 ScriptBuf::new(),
@@ -742,7 +742,7 @@ mod tests {
         let mut observed_sequence_path = false;
 
         for _ in 0..100 {
-            let selection = Selection::new(
+            let selection = TxTemplate::from_parts(
                 vec![regular_input.clone(), csv_input.clone()],
                 vec![output.clone()],
             );
@@ -789,7 +789,7 @@ mod tests {
         let (input, desc) = setup_cltv_input(time_locktime)?;
         let tip = absolute::Height::from_consensus(800_000)?;
 
-        let selection = Selection::new(
+        let selection = TxTemplate::from_parts(
             vec![input],
             vec![Output::with_descriptor(
                 desc.at_derivation_index(1)?,

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -385,17 +385,7 @@ impl TxTemplate {
     }
 
     /// Build the [`Psbt`] and its associated [`Finalizer`].
-    #[cfg(feature = "std")]
     pub fn create_psbt(self, params: PsbtBuildParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
-        self.create_psbt_with_rng(params, &mut rand::thread_rng())
-    }
-
-    /// Build the [`Psbt`] and its associated [`Finalizer`] with a custom `rng`.
-    pub fn create_psbt_with_rng(
-        self,
-        params: PsbtBuildParams,
-        _rng: &mut impl RngCore,
-    ) -> Result<(Psbt, Finalizer), BuildPsbtError> {
         let tx = self.to_unsigned_tx();
         let mut psbt = Psbt::from_unsigned_tx(tx).map_err(BuildPsbtError::Psbt)?;
 

--- a/src/tx_template.rs
+++ b/src/tx_template.rs
@@ -94,22 +94,31 @@ impl Display for SetLockTimeError {
 #[cfg(feature = "std")]
 impl std::error::Error for SetLockTimeError {}
 
-/// A fully-resolved tx shape — the workspace between coin selection and the final [`Psbt`]
-/// or [`Transaction`].
+/// A sealed, fully-resolved transaction shape — the read/emit core shared with [`TxTemplate`].
 ///
-/// Typically obtained from [`Selector::try_finalize`] (or
-/// [`InputCandidates::into_tx_template`]). Exposes the operations that *shape* the resulting
-/// transaction: input/output ordering, anti-fee-sniping, version/locktime overrides, and
-/// final emission to PSBT or [`Transaction`].
+/// Produced by [`TxTemplate::discourage_fee_sniping`]. Anti-fee-sniping is the terminal shaping
+/// step: it may protect the transaction by setting an input's `nSequence` instead of the
+/// locktime, which is only coherent while `tx.lock_time` is zero. Sealing makes that premise
+/// permanent — version, locktime, sequences and ordering are all fixed — so a later
+/// [`set_locktime`](TxTemplate::set_locktime) cannot reconstruct a transaction carrying both a
+/// near-tip locktime and a confirmation-depth sequence.
 ///
-/// New templates start with `version = TWO`, `lock_time = max(input CLTVs)` (or `ZERO`), and
-/// `fallback_sequence = ENABLE_RBF_NO_LOCKTIME`.
+/// [`TxTemplate`] derefs to this type, so every read/emit method here is also reachable on an
+/// unsealed template.
 ///
-/// [`Selector::try_finalize`]: crate::Selector::try_finalize
-/// [`InputCandidates::into_tx_template`]: crate::InputCandidates::into_tx_template
+/// ```compile_fail
+/// # use bdk_tx::TxTemplate;
+/// # use bitcoin::absolute;
+/// # let template: TxTemplate = unimplemented!();
+/// # let tip: absolute::Height = unimplemented!();
+/// # let mut rng = rand::thread_rng();
+/// // A locktime set after AFS could undo the nSequence path's premise, so it must not compile.
+/// let sealed = template.discourage_fee_sniping(tip, &mut rng).unwrap();
+/// let _ = sealed.set_locktime(absolute::LockTime::ZERO);
+/// ```
 #[derive(Debug, Clone)]
 #[must_use]
-pub struct TxTemplate {
+pub struct SealedTxTemplate {
     version: transaction::Version,
     lock_time: absolute::LockTime,
     fallback_sequence: Sequence,
@@ -117,179 +126,27 @@ pub struct TxTemplate {
     outputs: Vec<Output>,
 }
 
-impl TxTemplate {
-    pub(crate) fn new(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
-        let lock_time = max_input_cltv(&inputs).unwrap_or(absolute::LockTime::ZERO);
-        Self {
-            version: transaction::Version::TWO,
-            lock_time,
-            fallback_sequence: FALLBACK_SEQUENCE,
-            inputs,
-            outputs,
-        }
-    }
-
+impl SealedTxTemplate {
     /// Resolved transaction version.
     pub fn version(&self) -> transaction::Version {
         self.version
     }
-
-    /// Override `tx.version`.
-    ///
-    /// Default is [`transaction::Version::TWO`]. Setting a different value is allowed only when
-    /// no input has a relative timelock (BIP-68 requires v2 in that case).
-    ///
-    /// # Errors
-    ///
-    /// - [`SetVersionError::RelativeTimelockRequiresV2`] if `version < 2` and any input has a
-    ///   relative timelock.
-    pub fn set_version(mut self, version: transaction::Version) -> Result<Self, SetVersionError> {
-        if version < transaction::Version::TWO
-            && self.inputs.iter().any(|i| i.relative_timelock().is_some())
-        {
-            return Err(SetVersionError::RelativeTimelockRequiresV2 { attempted: version });
-        }
-        self.version = version;
-        Ok(self)
-    }
-
     /// Resolved transaction lock_time.
     pub fn lock_time(&self) -> absolute::LockTime {
         self.lock_time
     }
-
-    /// Set the fallback `nSequence` used for inputs that don't specify their own.
-    ///
-    /// The fallback is applied lazily at materialization (in [`Self::to_unsigned_tx`] and
-    /// [`Self::build_psbt`]); calling this method after other transformations does not
-    /// retroactively change inputs whose sequence has already been set explicitly (e.g. by
-    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping)).
-    pub fn set_fallback_sequence(mut self, sequence: Sequence) -> Self {
-        self.fallback_sequence = sequence;
-        self
-    }
-
-    /// Override `tx.lock_time`.
-    ///
-    /// Returns an error if `lock_time` would conflict with an input's required CLTV
-    /// (either by being below the requirement, or by using a different unit).
-    ///
-    /// Setting `lock_time` to a non-zero value when *every* input has `nSequence::MAX`
-    /// is *not* rejected, but per BIP-65 / Bitcoin's `IsFinalTx` rule the lock_time will
-    /// then be ignored at validation time.
-    ///
-    /// The value acts as a *floor*: `tx.lock_time` only ever moves up from here. A subsequent
-    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping) may raise it toward the chain
-    /// tip, but never lowers it. Note the converse of that: if you set a value within ~100
-    /// blocks of the tip, AFS's random backoff has no room below it and is effectively
-    /// truncated.
-    ///
-    /// Call this *before* [`discourage_fee_sniping`](Self::discourage_fee_sniping), not after.
-    /// AFS may protect the transaction by setting an input's `nSequence` instead of the
-    /// locktime, which it only does while `tx.lock_time` is zero; giving the locktime a value
-    /// afterwards produces a transaction carrying both, which is a distinctive fingerprint.
-    ///
-    /// # Errors
-    ///
-    /// - [`SetLockTimeError::BelowInputCltv`] if `lock_time < required` (same unit).
-    /// - [`SetLockTimeError::UnitMismatch`] if `lock_time` is height-based and an input's
-    ///   CLTV is time-based (or vice versa).
-    pub fn set_locktime(mut self, lock_time: absolute::LockTime) -> Result<Self, SetLockTimeError> {
-        for input in &self.inputs {
-            let Some(required) = input.absolute_timelock() else {
-                continue;
-            };
-            if !required.is_same_unit(lock_time) {
-                return Err(SetLockTimeError::UnitMismatch {
-                    input: required,
-                    attempted: lock_time,
-                });
-            }
-            if !required.is_implied_by(lock_time) {
-                return Err(SetLockTimeError::BelowInputCltv {
-                    required,
-                    attempted: lock_time,
-                });
-            }
-        }
-        self.lock_time = lock_time;
-        Ok(self)
-    }
-
     /// Fallback `nSequence` applied to inputs that don't specify their own.
     pub fn fallback_sequence(&self) -> Sequence {
         self.fallback_sequence
     }
-
     /// Inputs in this template.
     pub fn inputs(&self) -> &[Input] {
         &self.inputs
     }
-
     /// Outputs in this template.
     pub fn outputs(&self) -> &[Output] {
         &self.outputs
     }
-
-    /// Mutable handle to the input spending `outpoint`, if any.
-    ///
-    /// Returns [`None`] if no input in this template spends `outpoint`. The returned
-    /// [`InputMut`] only permits mutations that preserve the template's invariants — see
-    /// [`InputMut`] for the available operations.
-    pub fn input_mut(&mut self, outpoint: OutPoint) -> Option<InputMut<'_>> {
-        self.inputs
-            .iter_mut()
-            .find(|input| input.prev_outpoint() == outpoint)
-            .map(InputMut::new)
-    }
-
-    /// Iterator yielding a mutable handle to every input in this template.
-    ///
-    /// Each yielded [`InputMut`] only permits mutations that preserve the template's
-    /// invariants — see [`InputMut`] for the available operations.
-    pub fn inputs_mut(&mut self) -> impl Iterator<Item = InputMut<'_>> {
-        self.inputs.iter_mut().map(InputMut::new)
-    }
-
-    /// Reorder inputs using `compare`. Uses a stable sort.
-    ///
-    /// Typical use is BIP-69 lexicographic ordering by previous outpoint.
-    pub fn sort_inputs_by<F>(mut self, compare: F) -> Self
-    where
-        F: FnMut(&Input, &Input) -> Ordering,
-    {
-        self.inputs.sort_by(compare);
-        self
-    }
-
-    /// Randomly shuffle inputs using `rng`.
-    ///
-    /// Useful for chain-analysis resistance when no deterministic ordering is required.
-    pub fn shuffle_inputs<R: RngCore>(mut self, rng: &mut R) -> Self {
-        fisher_yates_shuffle(&mut self.inputs, rng);
-        self
-    }
-
-    /// Reorder outputs using `compare`. Uses a stable sort.
-    ///
-    /// Typical use is BIP-69 (ascending by amount, then by `script_pubkey`).
-    pub fn sort_outputs_by<F>(mut self, compare: F) -> Self
-    where
-        F: FnMut(&Output, &Output) -> Ordering,
-    {
-        self.outputs.sort_by(compare);
-        self
-    }
-
-    /// Randomly shuffle outputs using `rng`.
-    ///
-    /// Useful for chain-analysis resistance — in particular, hiding which output is the
-    /// change.
-    pub fn shuffle_outputs<R: RngCore>(mut self, rng: &mut R) -> Self {
-        fisher_yates_shuffle(&mut self.outputs, rng);
-        self
-    }
-
     /// Materialize the unsigned `bitcoin::Transaction` represented by this template.
     ///
     /// Each input's `nSequence` is its own [`Input::sequence`] if set, otherwise
@@ -310,38 +167,6 @@ impl TxTemplate {
             output: self.outputs.iter().map(Output::txout).collect(),
         }
     }
-
-    /// Apply BIP-326 anti-fee-sniping (AFS) protection using `tip_height` as the chain tip.
-    ///
-    /// AFS discourages miners from reorganizing recent blocks to capture fees by constraining
-    /// the transaction to only be valid at or after the chain tip. This sets either
-    /// `tx.lock_time` (via [`set_locktime`](Self::set_locktime)) or the `nSequence` of one
-    /// Taproot input (via [`Input::set_sequence`]).
-    ///
-    /// `tx.lock_time` only ever moves up: AFS raises it toward `tip_height` but never lowers a
-    /// value already in place, whether that came from an input's CLTV or from
-    /// [`set_locktime`](Self::set_locktime). So if `tx.lock_time` is already a block height
-    /// greater than the AFS target, this leaves it unchanged — the existing value by itself
-    /// prevents inclusion before `tip_height + 1`.
-    ///
-    /// AFS only operates on a height-based `tx.lock_time`. If the locktime in effect is
-    /// time-based, this returns [`AntiFeeSnipingError::UnsupportedLockTime`].
-    ///
-    /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki).
-    ///
-    /// # Errors
-    ///
-    /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `version < 2`.
-    /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `tx.lock_time` is time-based, from
-    ///   either an input's CLTV or [`set_locktime`](Self::set_locktime).
-    pub fn discourage_fee_sniping<R: RngCore>(
-        self,
-        tip_height: absolute::Height,
-        rng: &mut R,
-    ) -> Result<Self, AntiFeeSnipingError> {
-        discourage_fee_sniping(self, tip_height, rng)
-    }
-
     /// Build the [`Psbt`] and its associated [`Finalizer`].
     pub fn build_psbt(self, params: BuildPsbtParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
         let tx = self.to_unsigned_tx();
@@ -393,6 +218,232 @@ impl TxTemplate {
         }));
 
         Ok((psbt, finalizer))
+    }
+}
+
+/// A fully-resolved tx shape — the workspace between coin selection and the final [`Psbt`]
+/// or [`Transaction`].
+///
+/// Typically obtained from [`Selector::try_finalize`] (or
+/// [`InputCandidates::into_tx_template`]). Exposes the operations that *shape* the resulting
+/// transaction: input/output ordering, version/locktime overrides, and final emission to PSBT
+/// or [`Transaction`]. Anti-fee-sniping is the terminal shaping step — it consumes the template
+/// and yields a [`SealedTxTemplate`] that can only be read and emitted.
+///
+/// All read/emit methods come from [`SealedTxTemplate`] via [`Deref`](core::ops::Deref); this
+/// type adds the mutators on top.
+///
+/// New templates start with `version = TWO`, `lock_time = max(input CLTVs)` (or `ZERO`), and
+/// `fallback_sequence = ENABLE_RBF_NO_LOCKTIME`.
+///
+/// [`Selector::try_finalize`]: crate::Selector::try_finalize
+/// [`InputCandidates::into_tx_template`]: crate::InputCandidates::into_tx_template
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct TxTemplate(SealedTxTemplate);
+
+impl core::ops::Deref for TxTemplate {
+    type Target = SealedTxTemplate;
+
+    fn deref(&self) -> &SealedTxTemplate {
+        &self.0
+    }
+}
+
+impl TxTemplate {
+    pub(crate) fn new(inputs: Vec<Input>, outputs: Vec<Output>) -> Self {
+        let lock_time = max_input_cltv(&inputs).unwrap_or(absolute::LockTime::ZERO);
+        Self(SealedTxTemplate {
+            version: transaction::Version::TWO,
+            lock_time,
+            fallback_sequence: FALLBACK_SEQUENCE,
+            inputs,
+            outputs,
+        })
+    }
+
+    /// Override `tx.version`.
+    ///
+    /// Default is [`transaction::Version::TWO`]. Setting a different value is allowed only when
+    /// no input has a relative timelock (BIP-68 requires v2 in that case).
+    ///
+    /// # Errors
+    ///
+    /// - [`SetVersionError::RelativeTimelockRequiresV2`] if `version < 2` and any input has a
+    ///   relative timelock.
+    pub fn set_version(mut self, version: transaction::Version) -> Result<Self, SetVersionError> {
+        if version < transaction::Version::TWO
+            && self
+                .0
+                .inputs
+                .iter()
+                .any(|i| i.relative_timelock().is_some())
+        {
+            return Err(SetVersionError::RelativeTimelockRequiresV2 { attempted: version });
+        }
+        self.0.version = version;
+        Ok(self)
+    }
+
+    /// Set the fallback `nSequence` used for inputs that don't specify their own.
+    ///
+    /// The fallback is applied lazily at materialization (in [`SealedTxTemplate::to_unsigned_tx`] and
+    /// [`Self::build_psbt`]); calling this method after other transformations does not
+    /// retroactively change inputs whose sequence has already been set explicitly (e.g. by
+    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping)).
+    pub fn set_fallback_sequence(mut self, sequence: Sequence) -> Self {
+        self.0.fallback_sequence = sequence;
+        self
+    }
+
+    /// Override `tx.lock_time`.
+    ///
+    /// Returns an error if `lock_time` would conflict with an input's required CLTV
+    /// (either by being below the requirement, or by using a different unit).
+    ///
+    /// Setting `lock_time` to a non-zero value when *every* input has `nSequence::MAX`
+    /// is *not* rejected, but per BIP-65 / Bitcoin's `IsFinalTx` rule the lock_time will
+    /// then be ignored at validation time.
+    ///
+    /// The value acts as a *floor*: `tx.lock_time` only ever moves up from here. A subsequent
+    /// [`discourage_fee_sniping`](Self::discourage_fee_sniping) may raise it toward the chain
+    /// tip, but never lowers it. Note the converse of that: if you set a value within ~100
+    /// blocks of the tip, AFS's random backoff has no room below it and is effectively
+    /// truncated.
+    ///
+    /// This cannot be called after [`discourage_fee_sniping`](Self::discourage_fee_sniping),
+    /// which seals the template — AFS may protect the transaction by setting an input's
+    /// `nSequence` instead of the locktime, and that is only coherent while `tx.lock_time`
+    /// is zero.
+    ///
+    /// # Errors
+    ///
+    /// - [`SetLockTimeError::BelowInputCltv`] if `lock_time < required` (same unit).
+    /// - [`SetLockTimeError::UnitMismatch`] if `lock_time` is height-based and an input's
+    ///   CLTV is time-based (or vice versa).
+    pub fn set_locktime(mut self, lock_time: absolute::LockTime) -> Result<Self, SetLockTimeError> {
+        for input in &self.0.inputs {
+            let Some(required) = input.absolute_timelock() else {
+                continue;
+            };
+            if !required.is_same_unit(lock_time) {
+                return Err(SetLockTimeError::UnitMismatch {
+                    input: required,
+                    attempted: lock_time,
+                });
+            }
+            if !required.is_implied_by(lock_time) {
+                return Err(SetLockTimeError::BelowInputCltv {
+                    required,
+                    attempted: lock_time,
+                });
+            }
+        }
+        self.0.lock_time = lock_time;
+        Ok(self)
+    }
+
+    /// Mutable handle to the input spending `outpoint`, if any.
+    ///
+    /// Returns [`None`] if no input in this template spends `outpoint`. The returned
+    /// [`InputMut`] only permits mutations that preserve the template's invariants — see
+    /// [`InputMut`] for the available operations.
+    pub fn input_mut(&mut self, outpoint: OutPoint) -> Option<InputMut<'_>> {
+        self.0
+            .inputs
+            .iter_mut()
+            .find(|input| input.prev_outpoint() == outpoint)
+            .map(InputMut::new)
+    }
+
+    /// Iterator yielding a mutable handle to every input in this template.
+    ///
+    /// Each yielded [`InputMut`] only permits mutations that preserve the template's
+    /// invariants — see [`InputMut`] for the available operations.
+    pub fn inputs_mut(&mut self) -> impl Iterator<Item = InputMut<'_>> {
+        self.0.inputs.iter_mut().map(InputMut::new)
+    }
+
+    /// Reorder inputs using `compare`. Uses a stable sort.
+    ///
+    /// Typical use is BIP-69 lexicographic ordering by previous outpoint.
+    pub fn sort_inputs_by<F>(mut self, compare: F) -> Self
+    where
+        F: FnMut(&Input, &Input) -> Ordering,
+    {
+        self.0.inputs.sort_by(compare);
+        self
+    }
+
+    /// Randomly shuffle inputs using `rng`.
+    ///
+    /// Useful for chain-analysis resistance when no deterministic ordering is required.
+    pub fn shuffle_inputs<R: RngCore>(mut self, rng: &mut R) -> Self {
+        fisher_yates_shuffle(&mut self.0.inputs, rng);
+        self
+    }
+
+    /// Reorder outputs using `compare`. Uses a stable sort.
+    ///
+    /// Typical use is BIP-69 (ascending by amount, then by `script_pubkey`).
+    pub fn sort_outputs_by<F>(mut self, compare: F) -> Self
+    where
+        F: FnMut(&Output, &Output) -> Ordering,
+    {
+        self.0.outputs.sort_by(compare);
+        self
+    }
+
+    /// Randomly shuffle outputs using `rng`.
+    ///
+    /// Useful for chain-analysis resistance — in particular, hiding which output is the
+    /// change.
+    pub fn shuffle_outputs<R: RngCore>(mut self, rng: &mut R) -> Self {
+        fisher_yates_shuffle(&mut self.0.outputs, rng);
+        self
+    }
+
+    /// Apply BIP-326 anti-fee-sniping (AFS) protection using `tip_height` as the chain tip.
+    ///
+    /// AFS discourages miners from reorganizing recent blocks to capture fees by constraining
+    /// the transaction to only be valid at or after the chain tip. This sets either
+    /// `tx.lock_time` (via [`set_locktime`](Self::set_locktime)) or the `nSequence` of one
+    /// Taproot input (via [`Input::set_sequence`]).
+    ///
+    /// `tx.lock_time` only ever moves up: AFS raises it toward `tip_height` but never lowers a
+    /// value already in place, whether that came from an input's CLTV or from
+    /// [`set_locktime`](Self::set_locktime). So if `tx.lock_time` is already a block height
+    /// greater than the AFS target, this leaves it unchanged — the existing value by itself
+    /// prevents inclusion before `tip_height + 1`.
+    ///
+    /// AFS only operates on a height-based `tx.lock_time`. If the locktime in effect is
+    /// time-based, this returns [`AntiFeeSnipingError::UnsupportedLockTime`].
+    ///
+    /// AFS is the *final* shaping step: it consumes the template and returns a
+    /// [`SealedTxTemplate`], which permits only reads and emission. Apply any ordering,
+    /// version, locktime or sequence changes *before* calling this.
+    ///
+    /// See [BIP326](https://github.com/bitcoin/bips/blob/master/bip-0326.mediawiki).
+    ///
+    /// # Errors
+    ///
+    /// - [`AntiFeeSnipingError::UnsupportedVersion`] if `version < 2`.
+    /// - [`AntiFeeSnipingError::UnsupportedLockTime`] if `tx.lock_time` is time-based, from
+    ///   either an input's CLTV or [`set_locktime`](Self::set_locktime).
+    pub fn discourage_fee_sniping<R: RngCore>(
+        self,
+        tip_height: absolute::Height,
+        rng: &mut R,
+    ) -> Result<SealedTxTemplate, AntiFeeSnipingError> {
+        Ok(discourage_fee_sniping(self, tip_height, rng)?.0)
+    }
+
+    /// Build the [`Psbt`] and its associated [`Finalizer`].
+    ///
+    /// Convenience for building without sealing; equivalent to the inherent
+    /// [`SealedTxTemplate::build_psbt`] on the unsealed shape.
+    pub fn build_psbt(self, params: BuildPsbtParams) -> Result<(Psbt, Finalizer), BuildPsbtError> {
+        self.0.build_psbt(params)
     }
 }
 


### PR DESCRIPTION
### Description

Closes #57. Based on #87.

`PsbtParams` was doing two jobs: it carried bitcoin-transaction-shape fields (`version`, `min_locktime`, sequence) *and* PSBT emission options. Anti-fee-sniping depended on the tx-shape half, so it was structurally pinned inside `create_psbt` — which meant every caller reckoned with two AFS error variants and an extra input whether they wanted AFS or not.

AFS isn't a PSBT concern. It decides a transaction's locktime and input sequences, so it belongs *before* emission — as in Bitcoin Core, where [`DiscourageFeeSniping` runs as a step before the transaction is built](https://github.com/bitcoin/bitcoin/blob/10ca73c02cbff59f2134c0c7da3b8d0a7e727475/src/wallet/rpc/spend.cpp#L108). It couldn't move without first splitting the tx-shape fields out of `PsbtParams`.

This PR renames `Selection` to `TxTemplate` and gives it those fields, so the tx shape is owned and observable before anything is emitted:

```
Selector::try_finalize() → TxTemplate → SealedTxTemplate → (Psbt, Finalizer) | Transaction
```

Mostly ergonomics, with one exception. On `master`, `PsbtParams { version: ONE, .. }` with a relative-timelock input builds a v1 transaction whose `OP_CSV` can never be satisfied — BIP-68 sequence locks only apply from v2 — and you find out when it's rejected. That's now `SetVersionError::RelativeTimelockRequiresV2`.

### Notes to the reviewers

Commit 1 is a pure rename — `TxTemplate` *is* `Selection`, not a new layer between it and the PSBT.

Three commits at the end respond to review:

- `discourage_fee_sniping` (was `apply_anti_fee_sniping`). `apply_*` reads as an independent transformation that composes with the other shaping methods, but AFS shares the `lock_time` slot with `set_locktime`. Also matches Core's naming.
- A docs commit stating how those two compose. `set_locktime` is a *floor*: `tx.lock_time` only moves up from there, AFS may raise it toward the tip but never lowers it — the same way input CLTVs already compose. I considered making AFS authoritative instead (last-write-wins) and decided against it: having AFS silently discard a value the caller explicitly set is the footgun this PR exists to remove, and it would make AFS the one operation in `TxTemplate` that can *lower* `lock_time`.
- AFS is sealed: `discourage_fee_sniping` consumes the template and returns a `SealedTxTemplate` exposing only reads and emission. This is narrower than it sounds — only AFS seals, so `set_locktime` before it still works. It rules out one concrete case: AFS may protect the transaction by setting an input's `nSequence` rather than the locktime, which it only does while `lock_time` is zero, and a `set_locktime` afterwards would rebuild a transaction carrying both a near-tip locktime and a confirmation-depth sequence — exactly the fingerprint #87 prevents. A `compile_fail` doctest pins it.

Points 1 and 3 of https://github.com/bitcoindevkit/bdk-tx/pull/73#issuecomment-5297469748 are not addressed here; point 2 is #87, which this builds on.

### Changelog notice

- Renamed `Selection` to `TxTemplate`, now the single workspace for transaction shaping (version, locktime, fallback sequence, per-input sequence, ordering, anti-fee-sniping, emission).
- `Selector::try_finalize` now returns `Option<TxTemplate>`; `InputCandidates::into_selection` is now `into_tx_template`, returning `Result<TxTemplate, IntoTxTemplateError>` (was `IntoSelectionError`).
- Split `PsbtParams` into `BuildPsbtParams` (emission-only). Tx-shape options moved to `TxTemplate` setters: `set_version`, `set_locktime`, `set_fallback_sequence`, `discourage_fee_sniping`.
- PSBT emission is `build_psbt` (renamed from `create_psbt`) and returns `(Psbt, Finalizer)`; its params/error are `BuildPsbtParams` / `BuildPsbtError`. `shuffle_inputs` is now consuming (returns `Self`).
- Anti-fee-sniping is `TxTemplate::discourage_fee_sniping` (was the `PsbtParams::anti_fee_sniping` field). It and `set_locktime` write the same `tx.lock_time` slot and compose monotonically: a value passed to `set_locktime` is a floor that AFS may raise toward the chain tip but never lowers.
- Anti-fee-sniping is terminal: `discourage_fee_sniping` consumes the `TxTemplate` and returns a new `SealedTxTemplate` that exposes only reads and emission, so the tx shape cannot be mutated after AFS. `TxTemplate` derefs to `SealedTxTemplate`.
- Behaviour change: previously-silent locktime handling is now explicit. A wrong-unit `min_locktime` was silently ignored and a below-CLTV value silently clamped; `set_locktime` now returns `SetLockTimeError::UnitMismatch` / `BelowInputCltv`, and `set_version` returns `SetVersionError::RelativeTimelockRequiresV2`. The hardcoded `ENABLE_RBF_NO_LOCKTIME` fallback sequence is now configurable via `set_fallback_sequence` (default unchanged).

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-tx/blob/master/CONTRIBUTING.md)
- [x] This PR breaks the existing API