### PR TITLE
fix(no_std_rand): guard random_range against n == 0

### DIFF
--- a/src/no_std_rand.rs
+++ b/src/no_std_rand.rs
@@ -6,7 +6,13 @@ pub(crate) fn random_probability(rng: &mut impl RngCore, n: u32) -> bool {
 }
 
 /// Returns a random value in the range [0, n) using unbiased rejection sampling.
+///
+/// Returns 0 when `n == 0`, as the range [0, 0) is empty (avoids a division-by-zero panic).
 pub(crate) fn random_range(rng: &mut impl RngCore, n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+
     let threshold = n.wrapping_neg() % n;
 
     loop {
@@ -40,5 +46,12 @@ mod tests {
         fisher_yates_shuffle(&mut shuffled, &mut OsRng);
         shuffled.sort();
         assert_eq!(shuffled, original);
+    }
+
+    #[test]
+    fn test_random_range_zero_does_not_panic() {
+        // The range [0, 0) is empty; `random_range` must return 0 rather than
+        // panic on `0u32.wrapping_neg() % 0`, an integer division-by-zero.
+        assert_eq!(random_range(&mut OsRng, 0), 0);
     }
 }


### PR DESCRIPTION
### Description

`random_range(rng, 0)` computed `threshold = 0u32.wrapping_neg() % 0` → `0 % 0`, triggering Rust's always-on checked division-by-zero panic (*"attempt to calculate the remainder with a divisor of zero"*) before the rejection-sampling loop even ran. `random_probability(rng, 0)` forwards to it and panicked too.

The doc advertised the result range as `[0, n)` with no `n > 0` precondition, so a caller passing a dynamic `n` that can be `0` got an unhandled panic.

This PR guards `random_range` to return `0` for the empty range `[0, 0)`.

### Notes to the reviewers

All current callers already guard against 0 (`afs.rs` short-circuits when `taproot_inputs` is empty; `fisher_yates_shuffle` iterates `i >= 1` so passes `n >= 2`), so this is a **latent** defect in a shared `pub(crate)` RNG primitive rather than a currently-reachable DoS — hence **low** severity (CWE-369).

Changes:
- `src/no_std_rand.rs`: early-return `0` when `n == 0`.
- Added `test_random_range_zero_does_not_panic`.

Originally surfaced by [Project Loupe](https://github.com/project-loupe/loupe).

### Changelog notice

Fixed: `random_range`/`random_probability` panicked with a division-by-zero when called with `n == 0`; the empty range `[0, 0)` now returns `0`.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-tx/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API

🤖 Generated with [Claude Code](https://claude.com/claude-code)