### PR TITLE
fix(signer): match BIP32 origin via `matches`, not string prefix

### DIFF
--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,6 +1,4 @@
 use alloc::collections::BTreeMap;
-use alloc::string::ToString;
-use alloc::vec::Vec;
 
 use bitcoin::{
     psbt::{GetKey, GetKeyError, KeyRequest},
@@ -34,28 +32,25 @@ impl GetKey for Signer {
                 }
                 (_, desc_sk) => {
                     for desc_sk in desc_sk.clone().into_single_keys() {
-                        if let KeyRequest::Bip32((fingerprint, derivation)) = &key_request {
-                            if let DescriptorSecretKey::XPrv(k) = desc_sk {
-                                // We have the xprv for the request
-                                if let Ok(Some(prv)) =
-                                    GetKey::get_key(&k.xkey, key_request.clone(), secp)
-                                {
-                                    return Ok(Some(prv));
-                                }
-                                // The key origin is a strict prefix of the request derivation
-                                if let Some((fp, path)) = &k.origin {
-                                    if fingerprint == fp
-                                        && derivation.to_string().starts_with(&path.to_string())
-                                    {
-                                        let to_derive = derivation
-                                            .into_iter()
-                                            .skip(path.len())
-                                            .cloned()
-                                            .collect::<Vec<_>>();
-                                        let derived = k.xkey.derive_priv(secp, &to_derive)?;
-                                        return Ok(Some(derived.to_priv()));
-                                    }
-                                }
+                        if let (DescriptorSecretKey::XPrv(k), KeyRequest::Bip32(key_source)) =
+                            (desc_sk, &key_request)
+                        {
+                            // Let miniscript's `matches` confirm this key represents the
+                            // request (handling the key origin and wildcard). We must not
+                            // fall back to `GetKey for Xpriv`: that signs anything under the
+                            // xprv's fingerprint, including paths the descriptor never
+                            // declares, e.g. a sibling of the wildcard branch.
+                            if k.matches(key_source, secp).is_some() {
+                                // `xkey` is anchored at the origin, so strip the origin
+                                // prefix from the master-relative request path; with no
+                                // origin the whole path is relative to `xkey`.
+                                let (_, derivation) = key_source;
+                                let to_derive = match &k.origin {
+                                    Some((_, origin)) => &derivation[origin.len()..],
+                                    None => derivation.as_ref(),
+                                };
+                                let derived = k.xkey.derive_priv(secp, &to_derive)?;
+                                return Ok(Some(derived.to_priv()));
                             }
                         }
                     }
@@ -70,6 +65,7 @@ impl GetKey for Signer {
 #[cfg(test)]
 mod test {
     use crate::bitcoin::bip32::ChildNumber;
+    use alloc::string::ToString;
     use core::str::FromStr;
     use std::string::String;
 
@@ -147,11 +143,6 @@ mod test {
                 desc: format!("tr([{fp}/{path}]{derived}/0/*)"),
                 derivation: format!("{path}/0/7"),
             },
-            TestCase {
-                name: "key origin matches request derivation",
-                desc: format!("tr([{fp}/{path}]{derived}/0/*)"),
-                derivation: path.to_string(),
-            },
         ];
 
         for test in cases {
@@ -167,6 +158,40 @@ mod test {
                 "test case failed: {}",
                 test.name
             );
+        }
+
+        Ok(())
+    }
+
+    // `matches` only signs for keys the descriptor actually represents. Requests
+    // that share the origin as a prefix but fall outside the declared derivation
+    // are rejected: the account-level key itself (request == origin) and a sibling
+    // of the wildcard branch (`/9/*` when the descriptor declares `/0/*`). This
+    // holds whether the descriptor holds the master xprv or an account xprv with
+    // an explicit origin.
+    #[test]
+    fn get_key_bip32_rejects_paths_outside_descriptor() -> anyhow::Result<()> {
+        let secp = Secp256k1::new();
+        let xprv: Xpriv = "tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L".parse()?;
+        let fp = xprv.fingerprint(&secp);
+        let path: DerivationPath = "86h/1h/0h".parse()?;
+        let derived = xprv.derive_priv(&secp, &path)?;
+
+        let descs = [
+            format!("tr({xprv}/{path}/0/*)"),
+            format!("tr([{fp}/{path}]{derived}/0/*)"),
+        ];
+        for desc in &descs {
+            for derivation in [path.to_string(), format!("{path}/9/7")] {
+                let deriv: DerivationPath = derivation.parse()?;
+                let req = KeyRequest::Bip32((fp, deriv));
+                let (_, keymap) = Descriptor::parse_descriptor(&secp, desc)?;
+                let res = Signer(keymap).get_key(req, &secp);
+                assert!(
+                    matches!(res, Ok(None)),
+                    "expected None for {derivation} on {desc}: {res:?}"
+                );
+            }
         }
 
         Ok(())
@@ -200,6 +225,28 @@ mod test {
             Ok(Some(k)) if k == exp_prv,
         ));
 
+        Ok(())
+    }
+
+    // The origin "84h/1h/0h/1" is a string prefix of "84h/1h/0h/10" even though
+    // m/84'/1'/0'/1 is NOT a derivation-path prefix of m/84'/1'/0'/10. The signer
+    // must reject this request instead of leaking the key at the origin path.
+    #[test]
+    fn get_key_bip32_string_prefix_not_path_prefix() -> anyhow::Result<()> {
+        let secp = Secp256k1::new();
+        let xprv: Xpriv = "tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L".parse()?;
+        let fp = xprv.fingerprint(&secp);
+
+        let origin_path: DerivationPath = "84h/1h/0h/1".parse()?;
+        let derived = xprv.derive_priv(&secp, &origin_path)?;
+        let desc = format!("wpkh([{fp}/{origin_path}]{derived}/*)");
+        let (_, keymap) = Descriptor::parse_descriptor(&secp, &desc)?;
+
+        let request_path: DerivationPath = "84h/1h/0h/10".parse()?;
+        let req = KeyRequest::Bip32((fp, request_path));
+        let res = Signer(keymap).get_key(req, &secp);
+
+        assert!(matches!(res, Ok(None)), "expected None, got: {res:?}");
         Ok(())
     }
 }


### PR DESCRIPTION
### Description

`Signer::get_key` decided whether a key origin `(fingerprint, path)` covered a `KeyRequest::Bip32` derivation by stringifying both paths and using `starts_with`:

```rust
derivation.to_string().starts_with(&path.to_string())
```

Because `DerivationPath` renders its `ChildNumber` components as `/`-joined decimals, this matched on character boundaries rather than path components. That produces false positives whenever the origin's stringified form is a substring of the request's:

- origin `m/1` vs request `m/10` (`"10".starts_with("1")`)
- origin `m/84'/1'/0'/1` vs request `m/84'/1'/0'/10`
- unhardened origin `.../0` vs hardened request `.../0'`

When a spurious match fires and the two paths share a component count, `skip(path.len())` leaves an empty `to_derive`, so the signer returns the private key at the *origin* path while claiming to satisfy an unrelated request — leaking a key the descriptor was never meant to expose.

This PR delegates the origin/derivation matching to miniscript's `DescriptorXKey::matches`, which confirms the key actually represents the request (accounting for the key origin and wildcard) instead of doing a raw prefix check. On a match it strips the origin prefix and derives the remainder from the xkey.

### Notes to the reviewers

`matches` performs an equality check (modulo the wildcard), so it is stricter than the previous prefix logic: it rejects requests that share the origin as a prefix but fall outside what the descriptor declares (e.g. the account-level key itself, or a sibling of the wildcard branch). This is the intended behavior.

Tests:
- `get_key_bip32_string_prefix_not_path_prefix` — origin `m/84'/1'/0'/1`, request `m/84'/1'/0'/10`: old code returns `Some(key at origin)`, fixed code returns `None`.
- `get_key_bip32_rejects_paths_outside_descriptor` — confirms a request equal to the origin and a sibling of the wildcard branch both return `None`.

Original bug reported via `llm-code-review` (CWE-697). Discovered by [Project Loupe](https://github.com/project-loupe/loupe).

#### Follow-up: remove `Signer` once upstream is fixed

`Signer` only exists because miniscript's own `GetKey` for key maps mis-derives BIP32 requests for descriptors that carry key-origin info (the `KeyMapWrapper` in 12.3.x derives the full path without stripping the origin; 13.0.0 strips the wrong amount). The upstream fix is [rust-miniscript#872](https://github.com/rust-bitcoin/rust-miniscript/pull/872), which is not yet released. **Once it ships in a release we can bump our minimum minor version of `miniscript` to, we should drop `bdk_tx::Signer` entirely and use miniscript's `GetKey` impl directly.**

### Changelog notice

Fixed: `Signer` matched a BIP32 key origin against a derivation request by string prefix instead of path-component prefix, which could cause it to return a private key for an unrelated derivation path.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-tx/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
