### PR TITLE
fix(afs): require zero locktime for the nSequence path

### DIFF
--- a/src/afs.rs
+++ b/src/afs.rs
@@ -117,7 +117,12 @@ pub(crate) fn apply_anti_fee_sniping(
         .collect();
 
     // Conditions that force nLockTime (vs nSequence).
-    let must_use_locktime = taproot_inputs.is_empty()
+    //
+    // The nSequence path exists so the tx resembles an off-chain settlement spending a timelock
+    // path, and those carry nLockTime = 0. So a locktime already pinned by an input's CLTV (or by
+    // `min_locktime`) rules the nSequence path out.
+    let must_use_locktime = tx.lock_time != LockTime::ZERO
+        || taproot_inputs.is_empty()
         || inputs.iter().any(|input| {
             let confirmation = input.confirmations(tip_height);
             confirmation == 0 || confirmation > MAX_RELATIVE_HEIGHT

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -646,6 +646,52 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: pre-fix, the AFS nSequence path could fire on a tx whose `lock_time` was
+    /// already non-zero, producing a tx carrying *both* a near-tip locktime and a
+    /// confirmation-depth sequence — a fingerprint matching neither an ordinary wallet spend nor
+    /// an off-chain settlement, which is what the nSequence path exists to imitate.
+    #[test]
+    fn test_anti_fee_sniping_sequence_path_requires_zero_locktime() -> anyhow::Result<()> {
+        let tip = absolute::Height::from_consensus(3_000)?;
+        // Below the AFS target, so it does not otherwise interfere with the locktime path.
+        let min_locktime = absolute::LockTime::from_consensus(2_000);
+
+        // A confirmed Taproot input with no CSV: without `min_locktime` this would make the
+        // nSequence path reachable, so the test also guards against the fix being a no-op.
+        let input = setup_test_input(2_500)?;
+
+        let selection = Selection::new(
+            vec![input],
+            vec![Output::with_script(
+                ScriptBuf::new(),
+                Amount::from_sat(9_000),
+            )],
+        );
+
+        for _ in 0..100 {
+            let psbt = selection.create_psbt(PsbtParams {
+                min_locktime,
+                anti_fee_sniping: Some(tip),
+                ..Default::default()
+            })?;
+            let tx = psbt.unsigned_tx;
+
+            assert_eq!(
+                tx.input[0].sequence,
+                Sequence::ENABLE_RBF_NO_LOCKTIME,
+                "AFS must not take the nSequence path when tx.lock_time is non-zero",
+            );
+            assert!(
+                (tip.to_consensus_u32() - 100..=tip.to_consensus_u32())
+                    .contains(&tx.lock_time.to_consensus_u32()),
+                "AFS must still set a near-tip locktime, got {}",
+                tx.lock_time,
+            );
+        }
+
+        Ok(())
+    }
+
     /// Regression: pre-fix, the AFS nSequence path could pick a Taproot input that already carried
     /// a CSV (relative-timelock) requirement and overwrite its sequence. The presence of a regular
     /// Taproot input ensures the sequence path remains reachable — so the test also catches a


### PR DESCRIPTION
### Description

Fixes https://github.com/bitcoindevkit/bdk-tx/pull/65#discussion_r3786557326 — point 2 of https://github.com/bitcoindevkit/bdk-tx/pull/73#issuecomment-5297469748.

The nSequence path exists so the tx resembles an off-chain settlement spending a timelock path, and those carry `nLockTime = 0` with a CSV-driven sequence.

#65 removed the `tx.lock_time = LockTime::ZERO` that path used to perform — correctly, since it regressed input CLTVs — but added no precondition in its place. So a tx whose locktime is already pinned, by an input's CLTV or by `min_locktime`, can come out with **both** a near-tip locktime and a confirmation-depth sequence. That matches neither an ordinary wallet spend nor a contract close: a third fingerprint, worse than either branch alone.

The path is only coherent at `lock_time == 0`, so make that a precondition:

```rust
let must_use_locktime = tx.lock_time != LockTime::ZERO
    || taproot_inputs.is_empty()
    || inputs.iter().any(|input| { /* ... */ });
```

### Changelog notice

```md
Fixed:
- Anti-fee-sniping only takes the `nSequence` path when `tx.lock_time` is zero. A locktime pinned by an input's CLTV or by `min_locktime` now always takes the `nLockTime` path.
```

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-tx/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API

🤖 Generated with [Claude Code](https://claude.com/claude-code)